### PR TITLE
Fix race condition on member update

### DIFF
--- a/src/org/jgroups/raft/util/RequestTable.java
+++ b/src/org/jgroups/raft/util/RequestTable.java
@@ -41,6 +41,11 @@ public class RequestTable<T> {
         return entry != null && entry.committed;
     }
 
+    /** number of requests being processed */
+    public synchronized int size() {
+        return requests.size();
+    }
+
     /** Notifies the CompletableFuture and then removes the entry for index */
     public synchronized void notifyAndRemove(int index, byte[] response, int offset, int length) {
         Entry entry=requests.get(index);


### PR DESCRIPTION
* Update member update flag with CAS to prevent two concurrent operations to succeed
* Return members thread-safely

Problem is reproduced when @Test(iterationCount=100) is added to DynamicMembershipTest::testAddServerSimultaneously method. Raft::requestTableSize method is added for reproducing the issue. Since I am not familiar with Jgroups, I didn't put @ManagedAttribute to it. 