### PR TITLE
Upgrade Mapdb to version 1.0.8

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -16,7 +16,7 @@
         <dependency org="org.jgroups"               name="jgroups"        rev="3.6.6.Final"/>
         <dependency org="org.apache.logging.log4j"  name="log4j-api"      rev="2.+"/>
         <dependency org="org.apache.logging.log4j"  name="log4j-core"     rev="2.+"/>
-        <dependency org="org.mapdb"                 name="mapdb"          rev="1.0.6"/>
+        <dependency org="org.mapdb"                 name="mapdb"          rev="1.0.8"/>
         <dependency org="org.fusesource.leveldbjni" name="leveldbjni-all" rev="1.8"/>
         <dependency org="org.testng"                name="testng"         rev="6.8.+"/>
         <dependency org="com.beust"                 name="jcommander"     rev="1.+"/>


### PR DESCRIPTION
Hi,

Mapdb has a new version 1.0.8 and a 2.x-beta too.

This is just a dependency upgrade to 1.0.8.

Thanks,
Andrea