### PR TITLE
squid:S1186 - Methods should not be empty

### DIFF
--- a/src/org/jgroups/protocols/raft/InMemoryLog.java
+++ b/src/org/jgroups/protocols/raft/InMemoryLog.java
@@ -52,7 +52,9 @@ public class InMemoryLog implements Log {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public void delete() {

--- a/src/org/jgroups/protocols/raft/InMemoryLog.java
+++ b/src/org/jgroups/protocols/raft/InMemoryLog.java
@@ -53,7 +53,7 @@ public class InMemoryLog implements Log {
 
     @Override
     public void close() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Requested operation is not supported.");
     }
 
     @Override

--- a/src/org/jgroups/protocols/raft/MapDBLog.java
+++ b/src/org/jgroups/protocols/raft/MapDBLog.java
@@ -15,6 +15,7 @@ import java.util.function.ObjIntConsumer;
  * @since  0.1
  */
 public class MapDBLog implements Log {
+    private static final String REQUESTED_OPERATION_IS_NOT_SUPPORTED = "Requested operation is not supported.";
     protected DB                         db;
     protected String                     filename;
     protected Atomic.Integer             current_term, last_appended, commit_index;
@@ -115,20 +116,20 @@ public class MapDBLog implements Log {
 
     @Override
     public void truncate(int index) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(REQUESTED_OPERATION_IS_NOT_SUPPORTED);
     }
 
     @Override
     public void deleteAllEntriesStartingFrom(int start_index) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(REQUESTED_OPERATION_IS_NOT_SUPPORTED);
     }
 
     public void forEach(ObjIntConsumer<LogEntry> function,int start_index,int end_index) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(REQUESTED_OPERATION_IS_NOT_SUPPORTED);
     }
 
     public void forEach(ObjIntConsumer<LogEntry> function) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(REQUESTED_OPERATION_IS_NOT_SUPPORTED);
     }
 
 

--- a/src/org/jgroups/protocols/raft/MapDBLog.java
+++ b/src/org/jgroups/protocols/raft/MapDBLog.java
@@ -115,19 +115,20 @@ public class MapDBLog implements Log {
 
     @Override
     public void truncate(int index) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void deleteAllEntriesStartingFrom(int start_index) {
+        throw new UnsupportedOperationException();
     }
 
     public void forEach(ObjIntConsumer<LogEntry> function,int start_index,int end_index) {
-
+        throw new UnsupportedOperationException();
     }
 
     public void forEach(ObjIntConsumer<LogEntry> function) {
-
+        throw new UnsupportedOperationException();
     }
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1186 - Methods should not be empty.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1186
Please let me know if you have any questions.
George Kankava