### PR TITLE
fix validation in LevelDBLog#checkForConsistency

### DIFF
--- a/src/org/jgroups/protocols/raft/LevelDBLog.java
+++ b/src/org/jgroups/protocols/raft/LevelDBLog.java
@@ -394,7 +394,7 @@ public class LevelDBLog implements Log {
         }
 
         LogEntry lastAppendedEntry = getLogEntry(lastAppended);
-        assert (lastAppendedEntry==null || lastAppendedEntry.term == currentTerm);
+        assert (lastAppendedEntry==null || lastAppendedEntry.term <= currentTerm);
 
     }
 


### PR DESCRIPTION
Scenario:
1) Cluster starts up, and one or more entries are appended via method
#append. This causes currentTerm and lastAppendedEntry.term to be equal
2) Cluster stops
3) Cluster starts up again, and during leader-election, a new term is
negotiated and stored ( without appending any entries afterwards)
4) Cluster stops
5) Cluster starts up, and #checkForConsistency throws an AssertionError
because currentTerm != lastAppendedEntry.term