### PR TITLE
Allows single node Raft to apply entries

### DIFF
--- a/tests/junit-functional/org/jgroups/tests/RequestTableTest.java
+++ b/tests/junit-functional/org/jgroups/tests/RequestTableTest.java
@@ -16,7 +16,7 @@ public class RequestTableTest {
 
     public void testSimple() {
         RequestTable<String> table=new RequestTable<>();
-        table.create(1, "A", future);
+        table.create(1, "A", future, 3);
         table.add(1, "A", 3);
         assert !table.isCommitted(1);
         boolean done=table.add(1, "B", 3);
@@ -26,4 +26,11 @@ public class RequestTableTest {
         assert table.isCommitted(1);
     }
 
+    public void testSingleNode() {
+        RequestTable<String> table=new RequestTable<>();
+        table.create(1, "A", future, 1);
+        assert table.isCommitted(1);
+        boolean done=table.add(1, "A", 1);
+        assert !done : "should only mark as committed once";
+    }
 }


### PR DESCRIPTION
Related to #69 

- pass majority to RequestTable on creation to commit entries immediately if possible
- check if entry is committed after setting it on the leader and apply it immediately if so

Note: as mentioned in #69, by using the leader's vote, we could allow the log entries to be appended asynchronously and once finished add the vote to the request table.

One small thing, I would have preferred that applying the entry is done after we return the future in `setAsync`, but I didn't see any facilities for this. I know some Raft implementations will sometimes decouple the state machine and the Raft itself in different execution contexts, such that applying is also done asynchronously; this has some other issues (i.e. buffering apply calls), but could be an approach.