### PR TITLE
Fixes #72 : ELECTION looks for RAFT and its subclasses

### DIFF
--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -353,7 +353,7 @@ public class ELECTION extends Protocol {
 
     protected <T extends Protocol> T findProtocol(Class<T> clazz) {
         for(Protocol p=up_prot; p != null; p=p.getUpProtocol()) {
-            if(p.getClass().equals(clazz))
+            if(clazz.isAssignableFrom(p.getClass()))
                 return (T)p;
         }
         throw new IllegalStateException(clazz.getSimpleName() + " not found above " + this.getClass().getSimpleName());


### PR DESCRIPTION
Inspired from https://github.com/belaban/JGroups/blob/1763ee1e06d2f71ee6ebdc8ab646ea4cc3b0b7f1/src/org/jgroups/stack/ProtocolStack.java#L751