### PR TITLE
typed exceptions when the leader is missing

### DIFF
--- a/src/org/jgroups/protocols/raft/REDIRECT.java
+++ b/src/org/jgroups/protocols/raft/REDIRECT.java
@@ -65,7 +65,7 @@ public class REDIRECT extends Protocol implements Settable, DynamicMembership {
     }
 
     @Override
-    public CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) {
+    public CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) throws Exception {
         Address leader=leader("set()");
 
         // we are the current leader: pass the call to the RAFT protocol
@@ -193,12 +193,12 @@ public class REDIRECT extends Protocol implements Settable, DynamicMembership {
         }
     }
 
-    protected Address leader(String req_type) {
+    protected Address leader(String req_type) throws RaftLeaderException {
         Address leader=raft.leader();
         if(leader == null)
-            throw new RuntimeException(String.format("there is currently no leader to forward %s request to", req_type));
+            throw new RaftLeaderException(String.format("there is currently no leader to forward %s request to", req_type));
         if(view != null && !view.containsMember(leader))
-            throw new RuntimeException("leader " + leader + " is not member of view " + view);
+            throw new RaftLeaderException("leader " + leader + " is not member of view " + view);
         return leader;
     }
 

--- a/src/org/jgroups/protocols/raft/RaftLeaderException.java
+++ b/src/org/jgroups/protocols/raft/RaftLeaderException.java
@@ -1,0 +1,7 @@
+package org.jgroups.protocols.raft;
+
+public class RaftLeaderException extends Exception {
+    public RaftLeaderException(String s) {
+        super(s);
+    }
+}

--- a/src/org/jgroups/protocols/raft/Settable.java
+++ b/src/org/jgroups/protocols/raft/Settable.java
@@ -42,5 +42,5 @@ public interface Settable {
      * @param length he number of bytes to be used in the buffer, starting at offset
      * @return A CompletableFuture which can be used to fetch the result.
      */
-    CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length);
+    CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) throws Exception;
 }

--- a/src/org/jgroups/raft/RaftHandle.java
+++ b/src/org/jgroups/raft/RaftHandle.java
@@ -75,7 +75,7 @@ public class RaftHandle implements Settable {
     }
 
     @Override
-    public CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) {
+    public CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) throws Exception {
         return settable.setAsync(buf, offset, length);
     }
 


### PR DESCRIPTION
I'm working on some code to detect a split-brain scenario, having these two exceptions typed would help somewhat.