### PR TITLE
[4.x] Use Collection instead of List for members() method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -241,7 +247,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -253,8 +259,8 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <!-- require JDK 1.7 to run the build -->
-                            <version>[8,)</version>
+                            <!-- require JDK 1.8 to run the build -->
+                            <version>[1.8,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
                             <version>3.0.4</version>

--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -160,13 +160,14 @@ public class ELECTION extends Protocol {
     }
 
     protected void handleView(View v) {
-        if(role == Role.Leader) {
-            if(v != null && v.size() < raft.majority())
-                changeRole(Role.Candidate);
+        if (v == null || v.size() >= raft.majority()) {
+            return;
         }
-        else { // follower or candidate
-            if(v != null && v.size() < raft.majority())
-                raft.leader(null);
+        if (role == Role.Leader) {
+            changeRole(Role.Candidate);
+        } else {
+            // follower or candidate
+            raft.leader(null);
         }
     }
 
@@ -235,10 +236,11 @@ public class ELECTION extends Protocol {
 
     protected synchronized void handleVoteResponse(int term) {
         if(role == Role.Candidate && term == raft.current_term) {
-            if(++current_votes >= raft.majority) {
+            int majority = raft.majority();
+            if(++current_votes >= majority) {
                 // we've got the majority: become leader
                 log.trace("%s: collected %d votes (majority=%d) in term %d -> becoming leader",
-                          local_addr, current_votes, raft.majority, term);
+                          local_addr, current_votes, majority, term);
                 changeRole(Role.Leader);
             }
         }

--- a/src/org/jgroups/protocols/raft/RAFT.java
+++ b/src/org/jgroups/protocols/raft/RAFT.java
@@ -1,20 +1,29 @@
 package org.jgroups.protocols.raft;
 
-import org.jgroups.*;
-import org.jgroups.annotations.*;
-import org.jgroups.conf.ClassConfigurator;
-import org.jgroups.raft.util.Bits2;
-import org.jgroups.raft.util.CommitTable;
-import org.jgroups.raft.util.RequestTable;
-import org.jgroups.stack.Protocol;
-import org.jgroups.util.*;
+import static org.jgroups.Message.TransientFlag.DONT_LOOPBACK;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +34,27 @@ import java.util.function.ObjIntConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.jgroups.Message.TransientFlag.DONT_LOOPBACK;
+import org.jgroups.Address;
+import org.jgroups.Event;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.jgroups.View;
+import org.jgroups.annotations.MBean;
+import org.jgroups.annotations.ManagedAttribute;
+import org.jgroups.annotations.ManagedOperation;
+import org.jgroups.annotations.Property;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.raft.util.Bits2;
+import org.jgroups.raft.util.CommitTable;
+import org.jgroups.raft.util.RequestTable;
+import org.jgroups.stack.Protocol;
+import org.jgroups.util.ExtendedUUID;
+import org.jgroups.util.MessageBatch;
+import org.jgroups.util.Streamable;
+import org.jgroups.util.TimeScheduler;
+import org.jgroups.util.Util;
+
+import net.jcip.annotations.GuardedBy;
 
 
 /**
@@ -64,9 +93,11 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
     protected String                  raft_id;
 
     /** The set of members defining the Raft cluster */
+    @GuardedBy("members")
     protected final List<String>      members=new ArrayList<>();
 
     @ManagedAttribute(description="Majority needed to achieve consensus; computed from members)")
+    @GuardedBy("members")
     protected int                     majority=-1;
 
     @ManagedAttribute(description="If true, we can change 'members' at runtime")
@@ -117,7 +148,6 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
     protected final AtomicBoolean     members_being_changed = new AtomicBoolean(false);
 
     /** The current role (follower, candidate or leader). Every node starts out as a follower */
-    @GuardedBy("impl_lock")
     protected volatile RaftImpl       impl=new Follower(this);
     protected volatile View           view;
     protected Address                 local_addr;
@@ -181,18 +211,14 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
 
     @Property(description="List of members (logical names); majority is computed from it")
     public void setMembers(String list) {
-        synchronized(members) {
-            this.members.clear();
-            this.members.addAll(new HashSet<>(Util.parseCommaDelimitedStrings(list)));
-            majority=members.size() / 2 +1;
-        }
+        members(Util.parseCommaDelimitedStrings(list));
     }
 
-    public RAFT members(List<String> list) {
+    public RAFT members(Collection<String> list) {
         synchronized(members) {
             this.members.clear();
             this.members.addAll(new HashSet<>(list));
-            majority=members.size() / 2 +1;
+            computeMajority();
         }
         return this;
     }
@@ -323,7 +349,7 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
         synchronized(members) {
             if(!members.contains(name)) {
                 members.add(name);
-                majority=members.size() / 2 +1;
+                computeMajority();
             }
         }
     }
@@ -332,7 +358,7 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
         if(name == null) return;
         synchronized(members) {
             if(members.remove(name))
-                majority=members.size() / 2 +1;
+                computeMajority();
         }
     }
 
@@ -411,7 +437,7 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
                 members.clear();
                 members.addAll(tmp);
             }
-            majority=members.size() / 2 + 1;
+            computeMajority();
         }
 
         // Set an AddressGenerator in channel which generates ExtendedUUIDs and adds the raft_id to the hashmap
@@ -430,8 +456,10 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
         if(raft_id == null)
             raft_id=InetAddress.getLocalHost().getHostName();
 
-        if(!members.contains(raft_id))
-            throw new IllegalStateException(String.format("raft-id %s is not listed in members %s", raft_id, this.members));
+        synchronized (members) {
+            if (!members.contains(raft_id))
+                throw new IllegalStateException(String.format("raft-id %s is not listed in members %s", raft_id, this.members));
+        }
 
         if(log_impl == null) {
             if(log_class == null)
@@ -1035,5 +1063,10 @@ public class RAFT extends Protocol implements Runnable, Settable, DynamicMembers
 
     public interface RoleChange {
         void roleChanged(Role role);
+    }
+
+    @GuardedBy("members")
+    private void computeMajority() {
+        majority = (members.size() / 2) + 1;
     }
 }


### PR DESCRIPTION
* Allow to use any collection to configure the members programatically
* Added "jcip-annotations" (intellij can detect the annotations and give
  warnings)
* fixed missing "syncrhonized" blocks