### PR TITLE
[5.x] Use Collection instead of List for members() method

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -21,5 +21,6 @@
         <dependency org="org.testng"                name="testng"         rev="6.14.+"/>
         <dependency org="com.beust"                 name="jcommander"     rev="1.+"/>
         <dependency org="commons-io"                name="commons-io"     rev="2.5"/>
+        <dependency org="net.jcip"                  name="jcip-annotations" rev="1.0"/>
     </dependencies>
 </ivy-module>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -207,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>

--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -158,13 +158,14 @@ public class ELECTION extends Protocol {
     }
 
     protected void handleView(View v) {
-        if(role == Role.Leader) {
-            if(v != null && v.size() < raft.majority())
-                changeRole(Role.Candidate);
+        if (v == null || v.size() >= raft.majority()) {
+            return;
         }
-        else { // follower or candidate
-            if(v != null && v.size() < raft.majority())
-                raft.leader(null);
+        if (role == Role.Leader) {
+            changeRole(Role.Candidate);
+        } else {
+            // follower or candidate
+            raft.leader(null);
         }
     }
 
@@ -233,10 +234,11 @@ public class ELECTION extends Protocol {
 
     protected synchronized void handleVoteResponse(int term) {
         if(role == Role.Candidate && term == raft.current_term) {
-            if(++current_votes >= raft.majority) {
+            int majority = raft.majority();
+            if(++current_votes >= majority) {
                 // we've got the majority: become leader
                 log.trace("%s: collected %d votes (majority=%d) in term %d -> becoming leader",
-                          local_addr, current_votes, raft.majority, term);
+                          local_addr, current_votes, majority, term);
                 changeRole(Role.Leader);
             }
         }


### PR DESCRIPTION
* Allow to use any collection to configure the members programatically
* Added "jcip-annotations" (intellij can detect the annotations and give
  warnings)
* fixed missing "syncrhonized" blocks