### PR TITLE
Add file based log

### DIFF
--- a/bin/jmh.sh
+++ b/bin/jmh.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BASEDIR=$(dirname $0)
+ROOTDIR=$(realpath ${BASEDIR}/..)
+LIBS="${ROOTDIR}/target/libs"
+CLASSES="${ROOTDIR}/target/classes"
+TEST_CLASSES="${ROOTDIR}/target/test-classes"
+CONFDIR="${ROOTDIR}/conf"
+
+function help() {
+  echo "$@"
+  echo ""
+  echo "tip: run '$0 -h' for JMH options"
+  exit 1
+}
+
+function check_if_exists_or_exit() {
+  [ ! -d "$@" ] && help "Missing '$@' directory. Run: 'mvn clean package -DskipTests' before running the JMH benchmark"
+}
+
+check_if_exists_or_exit ${LIBS}
+check_if_exists_or_exit ${CLASSES}
+check_if_exists_or_exit ${TEST_CLASSES}
+
+java -cp "${LIBS}/*":${CLASSES}:${TEST_CLASSES}:${CONFDIR} ${JAVA_OPTIONS} org.openjdk.jmh.Main org.jgroups.perf.LogJmhBenchmark $@

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <mapdb.version>1.0.8</mapdb.version>
         <commons-io.version>2.7</commons-io.version>
         <log4j.version>2.17.1</log4j.version>
+        <jmh.version>1.34</jmh.version>
+        <mashona.version>1.1.0</mashona.version>
 
         <conf.dir>${project.basedir}/conf</conf.dir>
         <tmp.dir>${project.basedir}/tmp</tmp.dir>
@@ -192,11 +194,30 @@
             <version>1.0</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.mashona</groupId>
+            <artifactId>mashona-logwriting</artifactId>
+            <version>${mashona.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -407,6 +428,24 @@
                     <!-- Disable modular classpath -->
                     <useModulePath>false</useModulePath>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                            <includeScope>test</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/src/org/jgroups/protocols/raft/FileBasedLog.java
+++ b/src/org/jgroups/protocols/raft/FileBasedLog.java
@@ -1,0 +1,232 @@
+package org.jgroups.protocols.raft;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.ObjIntConsumer;
+
+import org.apache.commons.io.FileUtils;
+import org.jgroups.Address;
+import org.jgroups.raft.filelog.LogEntryStorage;
+import org.jgroups.raft.filelog.MetadataStorage;
+
+/**
+ * A {@link Log} implementation stored in a file.
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public class FileBasedLog implements Log {
+
+   private final Object metadataLock = new Object();
+
+   private volatile File logDir;
+   private volatile Address votedFor;
+   private volatile int commitIndex;
+   private volatile int currentTerm;
+
+   private volatile MetadataStorage metadataStorage;
+   private volatile LogEntryStorage logEntryStorage;
+
+   @Override
+   public synchronized void init(String log_name, Map<String, String> args) throws Exception {
+      logDir = new File(log_name);
+      if (!logDir.exists() && !logDir.mkdirs()) {
+         throw new IllegalArgumentException("Unable to create directory " + logDir.getAbsolutePath());
+      } else if (!logDir.isDirectory()) {
+         throw new IllegalArgumentException("File " + logDir.getAbsolutePath() + " is not a directory!");
+      }
+
+      metadataStorage = new MetadataStorage(logDir);
+      metadataStorage.open();
+
+      logEntryStorage = new LogEntryStorage(logDir);
+      logEntryStorage.open();
+
+      commitIndex = metadataStorage.getCommitIndex();
+      currentTerm = metadataStorage.getCurrentTerm();
+      votedFor = metadataStorage.getVotedFor();
+
+      logEntryStorage.reload();
+   }
+
+   @Override
+   public synchronized void close() {
+      try {
+         MetadataStorage metadataStorage = this.metadataStorage;
+         if (metadataStorage != null) {
+            metadataStorage.close();
+         }
+         LogEntryStorage entryStorage = logEntryStorage;
+         if (entryStorage != null) {
+            entryStorage.close();
+         }
+      } catch (IOException e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   @Override
+   public synchronized void delete() {
+      try {
+         MetadataStorage storage = metadataStorage;
+         if (storage != null) {
+            storage.delete();
+         }
+         LogEntryStorage entryStorage = logEntryStorage;
+         if (entryStorage != null) {
+            entryStorage.delete();
+         }
+         if (logDir != null) {
+            FileUtils.deleteDirectory(logDir);
+            logDir = null;
+         }
+      } catch (IOException e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   @Override
+   public int currentTerm() {
+      return currentTerm;
+   }
+
+   @Override
+   public Log currentTerm(int new_term) {
+      synchronized (metadataLock) {
+         //assert new_term >= currentTerm;
+         try {
+            checkMetadataStarted().setCurrentTerm(new_term);
+            currentTerm = new_term;
+            return this;
+         } catch (IOException e) {
+            throw new IllegalStateException(e);
+         }
+      }
+   }
+
+   @Override
+   public Address votedFor() {
+      return votedFor;
+   }
+
+   @Override
+   public Log votedFor(Address member) {
+      synchronized (metadataLock) {
+         try {
+            checkMetadataStarted().setVotedFor(member);
+            votedFor = member;
+            return this;
+         } catch (IOException e) {
+            throw new IllegalStateException(e);
+         }
+      }
+   }
+
+   @Override
+   public int commitIndex() {
+      return commitIndex;
+   }
+
+   @Override
+   public Log commitIndex(int new_index) {
+      synchronized (metadataLock) {
+         assert new_index >= commitIndex;
+         try {
+            checkMetadataStarted().setCommitIndex(new_index);
+            commitIndex = new_index;
+            return this;
+         } catch (IOException e) {
+            throw new IllegalStateException();
+         }
+      }
+   }
+
+   @Override
+   public int firstAppended() {
+      return checkLogEntryStorageStarted().getFirstAppended();
+   }
+
+   @Override
+   public int lastAppended() {
+      return checkLogEntryStorageStarted().getLastAppended();
+   }
+
+   @Override
+   public void append(int index, boolean overwrite, LogEntry... entries) {
+      assert index > firstAppended();
+      assert index > commitIndex();
+      LogEntryStorage storage = checkLogEntryStorageStarted();
+      try {
+         int term = storage.write(index, entries, overwrite);
+         if (currentTerm != term) {
+            currentTerm(term);
+         }
+      } catch (IOException e) {
+         e.printStackTrace();
+      }
+   }
+
+   @Override
+   public LogEntry get(int index) {
+      try {
+         return checkLogEntryStorageStarted().getLogEntry(index);
+      } catch (IOException e) {
+         return null;
+      }
+   }
+
+   @Override
+   public void truncate(int index) {
+      assert index > firstAppended();
+      try {
+         checkLogEntryStorageStarted().removeOld(index);
+      } catch (IOException e) {
+         e.printStackTrace();
+      }
+   }
+
+   @Override
+   public synchronized void deleteAllEntriesStartingFrom(int start_index) {
+      assert start_index > commitIndex; // can we delete committed entries!? See org.jgroups.tests.LogTest.testDeleteEntriesFromFirst
+      assert start_index >= firstAppended();
+
+      LogEntryStorage storage = checkLogEntryStorageStarted();
+      try {
+         currentTerm(storage.removeNew(start_index));
+      } catch (IOException e) {
+         e.printStackTrace();
+      }
+   }
+
+
+   @Override
+   public void forEach(ObjIntConsumer<LogEntry> function, int start_index, int end_index) {
+      try {
+         checkLogEntryStorageStarted().forEach(function, start_index, end_index);
+      } catch (IOException e) {
+         e.printStackTrace();
+      }
+   }
+
+   @Override
+   public void forEach(ObjIntConsumer<LogEntry> function) {
+      forEach(function, firstAppended(), lastAppended());
+   }
+
+   private MetadataStorage checkMetadataStarted() {
+      MetadataStorage storage = metadataStorage;
+      if (storage == null) {
+         throw new IllegalStateException("Log not initialized");
+      }
+      return storage;
+   }
+
+   private LogEntryStorage checkLogEntryStorageStarted() {
+      LogEntryStorage storage = logEntryStorage;
+      if (storage == null) {
+         throw new IllegalStateException("Log not initialized");
+      }
+      return storage;
+   }
+}

--- a/src/org/jgroups/raft/filelog/BaseStorage.java
+++ b/src/org/jgroups/raft/filelog/BaseStorage.java
@@ -1,0 +1,77 @@
+package org.jgroups.raft.filelog;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+import org.jgroups.raft.util.pmem.FileProvider;
+
+/**
+ * Base class to store data in a file.
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public abstract class BaseStorage {
+
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   private final File storageFile;
+   private volatile FileChannel channel;
+
+   BaseStorage(File storageFile) {
+      this.storageFile = Objects.requireNonNull(storageFile);
+   }
+
+   public synchronized void open() throws IOException {
+      if (channel == null) {
+         channel = FileProvider.openChannel(storageFile, 1024, true, true);
+      }
+   }
+
+   public synchronized void close() throws IOException {
+      if (channel != null) {
+         channel.close();
+         channel = null;
+      }
+   }
+
+   public synchronized void delete() throws IOException {
+      if (channel != null) {
+         channel.close();
+         channel = null;
+      }
+      if (storageFile.exists()) {
+         if (!storageFile.delete()) {
+            log.warn("Failed to delete file " + storageFile.getAbsolutePath());
+         }
+      }
+   }
+
+   protected FileChannel checkOpen() throws IOException {
+      FileChannel fileChannel = channel;
+      if (fileChannel == null) {
+         throw new IOException("File " + storageFile.getAbsolutePath() + " not open!");
+      }
+      return fileChannel;
+   }
+
+   protected synchronized void truncateUntil(long position) throws IOException {
+      FileChannel existing = checkOpen();
+      File tmpFile = new File(storageFile.getParentFile(), storageFile.getName() + ".tmp");
+      FileChannel newChannel = FileProvider.openChannel(tmpFile, (int) existing.size(), true, true);
+      existing.transferTo(position, existing.size(), newChannel);
+      newChannel.close();
+      existing.close();
+      Files.move(tmpFile.toPath(), storageFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      channel = null;
+      open();
+   }
+
+}

--- a/src/org/jgroups/raft/filelog/FilePositionCache.java
+++ b/src/org/jgroups/raft/filelog/FilePositionCache.java
@@ -1,0 +1,87 @@
+package org.jgroups.raft.filelog;
+
+import java.util.Arrays;
+
+/**
+ * A mapping between the RAFT log index and where the log entry is stored in a file.
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public class FilePositionCache {
+
+   public static final int TOO_OLD = -1;
+   public static final int NO_CAPACITY = -2;
+   public static final int OK = 1;
+   private static final int SIZE_INCREMENT = 128;
+
+   private final long[] position;
+   private final int firstLogIndex;
+
+   public FilePositionCache(int firstLogIndex) {
+      this.position = new long[SIZE_INCREMENT];
+      this.firstLogIndex = firstLogIndex;
+      Arrays.fill(position, -1);
+   }
+
+   private FilePositionCache(int firstLogIndex, long[] position) {
+      this.position = position;
+      this.firstLogIndex = firstLogIndex;
+   }
+
+   public long getPosition(int index) {
+      int arrayIndex = toArrayIndex(index);
+      if (arrayIndex < 0) {
+         return TOO_OLD;
+      }
+      return arrayIndex < position.length ? position[arrayIndex] : NO_CAPACITY;
+   }
+
+   public int set(int logIndex, long position) {
+      int arrayIndex = toArrayIndex(logIndex);
+      if (arrayIndex < 0) {
+         return TOO_OLD;
+      }
+      if (arrayIndex >= this.position.length) {
+         return NO_CAPACITY;
+      }
+      this.position[arrayIndex] = position;
+      return OK;
+   }
+
+
+   public FilePositionCache expand() {
+      long[] pos = Arrays.copyOf(position, position.length + SIZE_INCREMENT);
+      Arrays.fill(pos, position.length, pos.length, -1);
+      return new FilePositionCache(firstLogIndex, pos);
+   }
+
+   private int toArrayIndex(int logIndex) {
+      return logIndex - firstLogIndex;
+   }
+
+   public int getFirstAppended() {
+      return firstLogIndex;
+   }
+
+   public void invalidate(int index) {
+      int arrayIndex = toArrayIndex(index);
+      if (arrayIndex < 0 || arrayIndex >= position.length) {
+         return;
+      }
+      Arrays.fill(position, toArrayIndex(index), position.length, -1);
+   }
+
+   public FilePositionCache deleteFrom(int index) {
+      int arrayIndex = toArrayIndex(index);
+      if (arrayIndex < 0 || arrayIndex >= position.length) {
+         throw new IllegalArgumentException();
+      }
+      long positionToDecrement = position[arrayIndex];
+      long[] pos = new long[position.length - arrayIndex];
+      for (int i = 0; i < pos.length; ++i) {
+         pos[i] = Math.max(position[i + arrayIndex] - positionToDecrement, -1);
+      }
+      return new FilePositionCache(index, pos);
+   }
+}

--- a/src/org/jgroups/raft/filelog/LogEntryStorage.java
+++ b/src/org/jgroups/raft/filelog/LogEntryStorage.java
@@ -1,0 +1,361 @@
+package org.jgroups.raft.filelog;
+
+import static org.jgroups.raft.filelog.FilePositionCache.NO_CAPACITY;
+import static org.jgroups.raft.filelog.FilePositionCache.OK;
+import static org.jgroups.raft.filelog.FilePositionCache.TOO_OLD;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Objects;
+import java.util.concurrent.locks.StampedLock;
+import java.util.function.ObjIntConsumer;
+
+import org.jgroups.Global;
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+import org.jgroups.protocols.raft.LogEntry;
+
+/**
+ * Stores the {@link LogEntry} into a file.
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public class LogEntryStorage extends BaseStorage {
+
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   private static final byte MAGIC_NUMBER = 0x01;
+   private static final String FILE_NAME = "entries.raft";
+   private static final int HEADER_SIZE = Global.INT_SIZE * 4 + 1;
+
+   private FilePositionCache positionCache;
+   private volatile int lastAppended;
+   private final StampedLock lock = new StampedLock();
+
+   public LogEntryStorage(File parentDir) {
+      super(new File(parentDir, FILE_NAME));
+      positionCache = new FilePositionCache(0);
+   }
+
+   public void reload() throws IOException {
+      long stamp = lock.writeLock();
+      try {
+         FileChannel channel = checkOpen();
+         Header header = readHeader(channel, 0);
+         if (header == null) {
+            positionCache = new FilePositionCache(0);
+            lastAppended = 0;
+            return;
+         }
+         positionCache = new FilePositionCache(header.index == 1 ? 0 : header.index);
+         setFilePosition(header);
+         lastAppended = header.index;
+
+         long position = header.nextPosition();
+
+         while (true) {
+            header = readHeader(channel, position);
+            if (header == null) {
+               return;
+            }
+            setFilePosition(header);
+            position = header.nextPosition();
+            lastAppended = header.index;
+         }
+      } finally {
+         lock.unlockWrite(stamp);
+      }
+   }
+
+   public int getFirstAppended() {
+      long stamp = lock.readLock();
+      try {
+         return positionCache.getFirstAppended();
+      } finally {
+         lock.unlockRead(stamp);
+      }
+   }
+
+   public int getLastAppended() {
+      return lastAppended;
+   }
+
+   public LogEntry getLogEntry(int index) throws IOException {
+      long stamp = lock.readLock();
+      try {
+         FileChannel channel = checkOpen();
+         long position = positionCache.getPosition(index);
+         if (position < 0) {
+            return null;
+         }
+         Header header = readHeader(channel, position);
+         if (header == null) {
+            return null;
+         }
+         return header.readLogEntry(channel);
+      } finally {
+         lock.unlockRead(stamp);
+      }
+   }
+
+   public int write(int startIndex, LogEntry[] entries, final boolean overwrite) throws IOException {
+      PositionCheck check = overwrite ?
+            PositionCheck.OVERWRITE :
+            PositionCheck.PUT_IF_ABSENT;
+      FileChannel channel = checkOpen();
+      long stamp = lock.writeLock();
+      try {
+         if (startIndex == 1) {
+            return appendLocked(channel, entries, 1, 0, check);
+         }
+         // find previous entry to append
+         long previousPosition = positionCache.getPosition(startIndex - 1);
+         if (previousPosition < 0) {
+            throw new IllegalStateException();
+         }
+         Header previous = readHeader(channel, previousPosition);
+         if (previous == null) {
+            throw new IllegalStateException();
+         }
+         return appendLocked(channel, entries, startIndex, previous.nextPosition(), check);
+      } finally {
+         lock.unlockWrite(stamp);
+      }
+   }
+
+   private void expandCapacity() {
+      positionCache = positionCache.expand();
+   }
+
+   private void setFilePosition(Header header) {
+      setFilePosition(header.index, header.position);
+   }
+
+   private void setFilePosition(int index, long position) {
+      do {
+         switch (positionCache.set(index, position)) {
+            case NO_CAPACITY:
+               expandCapacity();
+               break;
+            case TOO_OLD:
+               log.warn("Unable to set file position for index " + index + ". LogEntry is too old");
+            case OK:
+            default:
+               return;
+         }
+      } while (true);
+   }
+
+   private int appendLocked(FileChannel channel, LogEntry[] entries, int index, long position, PositionCheck check) throws IOException {
+      ByteBuffer buffer = null;
+      int term = 0;
+      channel.position(position);
+      for (LogEntry entry : entries) {
+         Header header = new Header(position, index, entry);
+         if (check.canWrite(channel, header, entry)) {
+            if (buffer == null || buffer.capacity() < header.totalLength) {
+               buffer = ByteBuffer.allocate(header.totalLength);
+            }
+            writeLogEntry(channel, header, entry, buffer);
+            term = Math.max(entry.term(), term);
+         }
+         position = header.nextPosition();
+         ++index;
+      }
+
+      lastAppended = index - 1;
+      positionCache.invalidate(index);
+      channel.truncate(position);
+      return term;
+   }
+
+   private static Header readHeader(FileChannel channel, long position) throws IOException {
+      ByteBuffer data = ByteBuffer.allocate(HEADER_SIZE);
+      channel.read(data, position);
+      data.flip();
+      if (data.remaining() != HEADER_SIZE) {
+         // corrupted data or non-existing data
+         return null;
+      }
+
+      return new Header(position, data).consistencyCheck();
+   }
+
+   private void writeLogEntry(FileChannel channel, Header header, LogEntry entry, ByteBuffer buffer) throws IOException {
+      header.writeTo(buffer);
+      buffer.put(entry.command(), entry.offset(), entry.length());
+      buffer.flip();
+      channel.write(buffer);
+      buffer.clear();
+      setFilePosition(header);
+   }
+
+   public void removeOld(int index) throws IOException {
+      long stamp = lock.writeLock();
+      try {
+         long position = positionCache.getPosition(index);
+         truncateUntil(position);
+         positionCache = positionCache.deleteFrom(index);
+      } finally {
+         lock.unlockWrite(stamp);
+      }
+   }
+
+   public int removeNew(int index) throws IOException {
+      long stamp = lock.readLock();
+      try {
+         FileChannel channel = checkOpen();
+         // remove all?
+         if (index == 1) {
+            channel.truncate(0);
+            lastAppended = 0;
+            return 0;
+         }
+         long position = positionCache.getPosition(index - 1);
+         Header previousHeader = readHeader(channel, position);
+         if (previousHeader == null) {
+            throw new IllegalStateException();
+         }
+         channel.truncate(previousHeader.nextPosition());
+         positionCache.invalidate(index);
+         lastAppended = index - 1;
+         return previousHeader.term;
+      } finally {
+         lock.unlockRead(stamp);
+      }
+   }
+
+   public void forEach(ObjIntConsumer<LogEntry> consumer, int startIndex, int endIndex) throws IOException {
+      startIndex = Math.max(Math.max(startIndex, getFirstAppended()), 1);
+      long stamp = lock.readLock();
+      try {
+         long position = positionCache.getPosition(startIndex);
+         if (position < 0) {
+            return;
+         }
+         FileChannel channel = checkOpen();
+         while (startIndex <= endIndex) {
+            Header header = readHeader(channel, position);
+            if (header == null) {
+               return;
+            }
+            consumer.accept(header.readLogEntry(channel), startIndex);
+            position = header.nextPosition();
+            ++startIndex;
+         }
+      } finally {
+         lock.unlockRead(stamp);
+      }
+   }
+
+   private enum PositionCheck {
+      OVERWRITE {
+         @Override
+         public boolean canWrite(FileChannel channel, Header header, LogEntry entry) {
+            return true;
+         }
+      },
+      PUT_IF_ABSENT {
+         @Override
+         public boolean canWrite(FileChannel channel, Header header, LogEntry entry) throws IOException {
+            Header existing = readHeader(channel, header.position);
+            if (existing == null) {
+               return true;
+            }
+            if (existing.equals(header)) { // same entry, skip overwriting
+               return false;
+            }
+            throw new IllegalStateException();
+         }
+      };
+
+      abstract boolean canWrite(FileChannel channel, Header header, LogEntry entry) throws IOException;
+   }
+
+   private static class Header {
+      final long position;
+      // magic is here in case we need to change the format!
+      final byte magic;
+      final int totalLength;
+      final int term;
+      final int index;
+      final int dataLength;
+
+      Header(long position, int index, LogEntry entry) {
+         Objects.requireNonNull(entry);
+         this.position = position;
+         this.magic = MAGIC_NUMBER;
+         this.index = index;
+         this.term = entry.term();
+         this.dataLength = entry.length();
+         this.totalLength = HEADER_SIZE + dataLength;
+      }
+
+      Header(long position, ByteBuffer buffer) {
+         this.position = position;
+         this.magic = buffer.get();
+         this.totalLength = buffer.getInt();
+         this.term = buffer.getInt();
+         this.index = buffer.getInt();
+         this.dataLength = buffer.getInt();
+      }
+
+      public void writeTo(ByteBuffer buffer) {
+         buffer.put(magic);
+         buffer.putInt(totalLength);
+         buffer.putInt(term);
+         buffer.putInt(index);
+         buffer.putInt(dataLength);
+      }
+
+      long nextPosition() {
+         return HEADER_SIZE + position + dataLength;
+      }
+
+      Header consistencyCheck() {
+         return magic != MAGIC_NUMBER ||
+               term <= 0 ||
+               index <= 0 ||
+               dataLength < 0 ||
+               totalLength < HEADER_SIZE ||
+               dataLength + HEADER_SIZE != totalLength ?
+               null : this;
+      }
+
+      LogEntry readLogEntry(FileChannel channel) throws IOException {
+         ByteBuffer data = ByteBuffer.allocate(dataLength);
+         channel.read(data, position + HEADER_SIZE);
+         data.flip();
+         if (data.remaining() != dataLength) {
+            return null;
+         }
+         if (data.hasArray()) {
+            return new LogEntry(term, data.array(), data.arrayOffset(), dataLength);
+         }
+         byte[] bytes = new byte[dataLength];
+         data.get(bytes);
+         return new LogEntry(term, bytes);
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+         Header header = (Header) o;
+         return position == header.position &&
+               magic == header.magic &&
+               totalLength == header.totalLength &&
+               term == header.term &&
+               index == header.index &&
+               dataLength == header.dataLength;
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(position, magic, totalLength, term, index, dataLength);
+      }
+   }
+}

--- a/src/org/jgroups/raft/filelog/MetadataStorage.java
+++ b/src/org/jgroups/raft/filelog/MetadataStorage.java
@@ -1,0 +1,108 @@
+package org.jgroups.raft.filelog;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.util.ByteBufferInputStream;
+import org.jgroups.util.Util;
+
+/**
+ * Stores the RAFT log metadata in a file.
+ * <p>
+ * The metadata includes the commit index, the current term and the last vote.
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public class MetadataStorage extends BaseStorage {
+
+   private static final String FILE_NAME = "metadata.raft";
+
+   private static final int COMMIT_INDEX_POS = 0;
+   private static final int CURRENT_TERM_POS = COMMIT_INDEX_POS + Global.INT_SIZE;
+   private static final int VOTED_FOR_POS = CURRENT_TERM_POS + Global.INT_SIZE;
+
+   public MetadataStorage(File parentDir) {
+      super(new File(parentDir, FILE_NAME));
+   }
+
+
+   public int getCommitIndex() throws IOException {
+      return readIntOrZero(COMMIT_INDEX_POS);
+   }
+
+   public void setCommitIndex(int commitIndex) throws IOException {
+      writeInt(commitIndex, COMMIT_INDEX_POS);
+   }
+
+   public int getCurrentTerm() throws IOException {
+      return readIntOrZero(CURRENT_TERM_POS);
+   }
+
+   public void setCurrentTerm(int term) throws IOException {
+      writeInt(term, CURRENT_TERM_POS);
+   }
+
+   public Address getVotedFor() throws IOException, ClassNotFoundException {
+      FileChannel fChannel = checkOpen();
+      // most addresses are quite small
+      ByteBuffer data = ByteBuffer.allocate(Global.INT_SIZE);
+      fChannel.read(data, VOTED_FOR_POS);
+      data.flip();
+      if (data.remaining() != Global.INT_SIZE) {
+         // corrupted?
+         return null;
+      }
+      int addressLength = data.getInt();
+      data = ByteBuffer.allocate(addressLength);
+      fChannel.read(data, VOTED_FOR_POS + Global.INT_SIZE);
+      data.flip();
+      if (data.remaining() != addressLength) {
+         //uname to read "addressLength" bytes
+         return null;
+      }
+      return readAddress(data);
+   }
+
+   public void setVotedFor(Address address) throws IOException {
+      FileChannel fChannel = checkOpen();
+      if (address == null) {
+         fChannel.truncate(VOTED_FOR_POS);
+         return;
+      }
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      Util.writeAddress(address, new DataOutputStream(baos));
+
+      byte[] data = baos.toByteArray();
+      ByteBuffer buffer = ByteBuffer.allocate(Global.INT_SIZE + data.length);
+      buffer.putInt(data.length);
+      buffer.put(data);
+      fChannel.write(buffer.flip(), VOTED_FOR_POS);
+   }
+
+   private int readIntOrZero(long position) throws IOException {
+      FileChannel fChannel = checkOpen();
+      ByteBuffer data = ByteBuffer.allocate(Global.INT_SIZE);
+      int read = fChannel.read(data, position);
+      data.flip();
+      return read == Global.INT_SIZE ? data.getInt() : 0;
+   }
+
+   private void writeInt(int value, long position) throws IOException {
+      FileChannel fChannel = checkOpen();
+      ByteBuffer data = ByteBuffer.allocate(Global.INT_SIZE);
+      data.putInt(value);
+      data.flip();
+      fChannel.write(data, position);
+   }
+
+   private static Address readAddress(ByteBuffer buffer) throws IOException, ClassNotFoundException {
+      return Util.readAddress(new ByteBufferInputStream(buffer));
+   }
+}

--- a/src/org/jgroups/raft/util/pmem/FileProvider.java
+++ b/src/org/jgroups/raft/util/pmem/FileProvider.java
@@ -1,0 +1,45 @@
+package org.jgroups.raft.util.pmem;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Creates {@link FileChannel}.
+ * <p>
+ * If a Persistence Memory drive is available, support is provided by https://github.com/jhalliday/mashona
+ *
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+public class FileProvider {
+
+   private static final boolean ATTEMPT_PMEM;
+
+   static {
+      boolean attemptPmem = false;
+      try {
+         Class.forName("io.mashona.logwriting.PmemUtil");
+         // use persistent memory if available, otherwise fallback to regular file.
+         attemptPmem = true;
+      } catch (ClassNotFoundException e) {
+         //no op
+      }
+      ATTEMPT_PMEM = attemptPmem;
+   }
+
+   public static FileChannel openChannel(File file, int length, boolean create, boolean readSharedMetadata) throws IOException {
+      FileChannel fileChannel = ATTEMPT_PMEM ? PmemUtilWrapper.pmemChannelFor(file, length, create, readSharedMetadata) : null;
+
+      if (fileChannel == null) {
+         if (!file.exists() && !create) {
+            return null;
+         }
+         return FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.READ);
+      }
+
+      return fileChannel;
+   }
+
+}

--- a/src/org/jgroups/raft/util/pmem/PmemUtilWrapper.java
+++ b/src/org/jgroups/raft/util/pmem/PmemUtilWrapper.java
@@ -1,0 +1,22 @@
+package org.jgroups.raft.util.pmem;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.channels.FileChannel;
+
+import io.mashona.logwriting.PmemUtil;
+
+/**
+ * This class is here solely for the purpose of encapsulating the {@link PmemUtil} class so we do not load it unless
+ * necessary, allowing this to be an optional dependency. Any code that invokes a method in this class should first
+ * check if the {@link PmemUtil} can be loaded via {@link Class#forName(String)} otherwise a {@link ClassNotFoundException}
+ * may be thrown when loading this class.
+ */
+public class PmemUtilWrapper {
+   /**
+    * Same as {@link PmemUtil#pmemChannelFor(File, int, boolean, boolean)}.
+    */
+   static public FileChannel pmemChannelFor(File file, int length, boolean create, boolean readSharedMetadata) throws FileNotFoundException {
+      return PmemUtil.pmemChannelFor(file, length, create, readSharedMetadata);
+   }
+}

--- a/tests/junit-functional/org/jgroups/perf/LogJmhBenchmark.java
+++ b/tests/junit-functional/org/jgroups/perf/LogJmhBenchmark.java
@@ -1,0 +1,97 @@
+package org.jgroups.perf;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.jgroups.protocols.raft.FileBasedLog;
+import org.jgroups.protocols.raft.LevelDBLog;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RocksDBLog;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Pedro Ruivo
+ * @since 0.5.4
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 4, time = 5)
+@Fork(1)
+public class LogJmhBenchmark {
+
+   public static void main(String[] args) throws RunnerException {
+      Options opt = new OptionsBuilder()
+            .include(LogJmhBenchmark.class.getCanonicalName())
+            .forks(1)
+            .build();
+
+      new Runner(opt).run();
+   }
+
+   @Benchmark
+   public void append(Blackhole bh, ExecutionPlan plan) {
+      plan.log.append(plan.index, false, plan.entry);
+      ++plan.index;
+   }
+
+   @State(Scope.Benchmark)
+   public static class ExecutionPlan {
+
+      @Param({"10", "100"})
+      private int dataSize;
+      @Param({"leveldb", "rocksdb", "file"})
+      private String logType;
+      @Param({"/tmp"})
+      private String baseDir;
+      private LogEntry entry;
+      private int index;
+      private Log log;
+
+      @Setup(Level.Trial)
+      public void setUp() throws Exception {
+         index = 1;
+         byte[] data = new byte[dataSize];
+         Arrays.fill(data, (byte) 1);
+         entry = new LogEntry(1, data);
+         if ("leveldb".equals(logType)) {
+            log = new LevelDBLog();
+         } else if ("rocksdb".equals(logType)) {
+            log = new RocksDBLog();
+         } else if ("file".equals(logType)) {
+            log = new FileBasedLog();
+         } else {
+            throw new IllegalArgumentException();
+         }
+         new File(baseDir).mkdirs();
+         log.init(baseDir + "/raft_" + logType, Collections.emptyMap());
+      }
+
+      @TearDown
+      public void stop() {
+         if (log != null) {
+            log.delete();
+         }
+      }
+   }
+}


### PR DESCRIPTION
Stores the log entries in a single file.

---

This is a side project that I've been working on. It introduces a new Log implementation that stores the LogEntry in a single file. The main use case is for users who do not want to use an external library (or add an external library to their project). 

Also, it uses https://github.com/jhalliday/mashona library to include support for persistent memory hardware (quoting: Persistent memory hardware is available today in the form of Non-Volatile Dual Inline Memory Module - N (NVDIMM-N).). This was not tested :) 

### Performance - JMH

JMH benchmark make is the slowest of the Log implementation. Worth mentioning that the performance degrades with the increase of the file size.

```
Benchmark               (baseDir)  (dataSize)  (logType)  Mode  Cnt      Score       Error  Units
LogJmhBenchmark.append      ./jmh          10    leveldb  avgt    4   4091.815 ±  2930.692  ns/op
LogJmhBenchmark.append      ./jmh          10    rocksdb  avgt    4  11757.408 ±  4821.800  ns/op
LogJmhBenchmark.append      ./jmh          10       file  avgt    4  21231.407 ± 24195.715  ns/op
LogJmhBenchmark.append      ./jmh         100    leveldb  avgt    4   4670.198 ±  2887.439  ns/op
LogJmhBenchmark.append      ./jmh         100    rocksdb  avgt    4  12098.928 ±  6752.654  ns/op
LogJmhBenchmark.append      ./jmh         100       file  avgt    4  22745.395 ± 14390.152  ns/op
```

ps. storing the data in SSD or in TMPFS didn't make any noticeable difference.

### Performance - IspnPerfTest

Surprisingly, the performance number with IspnPerfTest makes it on par with LevelDBLog.

**File-Based**
```
======================= Results: ===========================
C: 8,975.04 increments/sec (269,332 increments, 222 us / increment)
A: 16,531.74 increments/sec (496,035 increments, 120 us / increment)
B: 8,958.41 increments/sec (268,833 increments, 222 us / increment)

Throughput: 11,488.18 increments/sec/node
Time:       183 us / increment
```
**RocksDB**
```
======================= Results: ===========================
B: 5,517.87 increments/sec (165,939 increments, 362 us / increment)
A: 8,953.78 increments/sec (269,285 increments, 223 us / increment)
C: 5,478.64 increments/sec (164,759 increments, 364 us / increment)

Throughput: 6,650.15 increments/sec/node
Time:       314 us / increment
```

**LevelDB**
```
======================= Results: ===========================
A: 15,490.98 increments/sec (464,807 increments, 128 us / increment)
C: 8,222.07 increments/sec (246,728 increments, 242 us / increment)
B: 8,211.11 increments/sec (246,399 increments, 243 us / increment)

Throughput: 10,641.23 increments/sec/node
Time:       199 us / increment
```

### How to run JMH

There is a script in `bin` directory. Just run it with:
```
./bin/jmh.sh
```