### PR TITLE
Expose sync of the file-based log - adding log entry storage (#131)

### DIFF
--- a/src/org/jgroups/raft/filelog/LogEntryStorage.java
+++ b/src/org/jgroups/raft/filelog/LogEntryStorage.java
@@ -284,6 +284,7 @@ public class LogEntryStorage {
    }
 
    public void useFsync(final boolean value) {
+      this.fsync = value;
    }
 
    private static class Header {


### PR DESCRIPTION
On https://github.com/belaban/jgroups-raft/pull/134 I've forgot to implement the useFsync method on the log entry storage: adding now