### PR TITLE
Improve installing a new snapshot

### DIFF
--- a/src/org/jgroups/protocols/raft/FileBasedLog.java
+++ b/src/org/jgroups/protocols/raft/FileBasedLog.java
@@ -191,7 +191,7 @@ public class FileBasedLog implements Log {
 
    @Override
    public void truncate(int index) {
-      assert index > firstAppended();
+      assert index >= firstAppended();
       try {
          checkLogEntryStorageStarted().removeOld(index);
       } catch (IOException e) {

--- a/src/org/jgroups/protocols/raft/Follower.java
+++ b/src/org/jgroups/protocols/raft/Follower.java
@@ -33,15 +33,12 @@ public class Follower extends RaftImpl {
             ByteArrayDataInputStream in=new ByteArrayDataInputStream(msg.getArray(), msg.getOffset(), msg.getLength());
             sm.readContentFrom(in);
 
-            raft.doSnapshot();
-
-            // insert a dummy entry
-            Log log=raft.log();
-            log.append(last_included_index, true, new LogEntry(last_included_term, null));
             raft.last_appended=last_included_index;
-            log.commitIndex(last_included_index);
             raft.commit_index=last_included_index;
-            log.truncate(last_included_index);
+
+            Log log=raft.log();
+            log.commitIndex(last_included_index);
+            raft.doSnapshot();
 
             raft.getLog().debug("%s: applied snapshot (%s) from %s; last_appended=%d, commit_index=%d",
                                 raft.getAddress(), Util.printBytes(msg.getLength()), msg.src(), raft.lastAppended(),

--- a/src/org/jgroups/protocols/raft/InMemoryLog.java
+++ b/src/org/jgroups/protocols/raft/InMemoryLog.java
@@ -135,6 +135,9 @@ public class InMemoryLog implements Log {
         System.arraycopy(entries, idx, tmp, 0, entries.length - idx);
         entries=tmp;
         first_appended=index;
+        if (last_appended < index) {
+            last_appended = index;
+        }
     }
 
     @Override

--- a/src/org/jgroups/protocols/raft/LevelDBLog.java
+++ b/src/org/jgroups/protocols/raft/LevelDBLog.java
@@ -194,7 +194,7 @@ public class LevelDBLog implements Log {
 
     @Override
     public void truncate(int upto_index) {
-        if(upto_index< firstAppended || upto_index> lastAppended)
+        if(upto_index< firstAppended)
             return;
 
         if(upto_index > commitIndex) {
@@ -210,6 +210,12 @@ public class LevelDBLog implements Log {
                 batch.delete(fromIntToByteArray(index));
             }
             batch.put(FIRSTAPPENDED, fromIntToByteArray(upto_index));
+
+            if (lastAppended < upto_index) {
+                lastAppended = upto_index;
+                batch.put(LASTAPPENDED, fromIntToByteArray(upto_index));
+            }
+
             db.write(batch, write_options);
             firstAppended=upto_index;
         }

--- a/src/org/jgroups/raft/filelog/FilePositionCache.java
+++ b/src/org/jgroups/raft/filelog/FilePositionCache.java
@@ -203,7 +203,8 @@ public class FilePositionCache {
       }
       final long positionToDecrement = positionPage.get(pageOffset);
       if (positionToDecrement == EMPTY) {
-         throw new IllegalArgumentException();
+         // if empty, we do not need to copy anything.
+         return new FilePositionCache(logIndex);
       }
       // copy from cacheIndex until lastNotEmptyIndex
       final int oldPages = positionPages.size();

--- a/src/org/jgroups/raft/filelog/LogEntryStorage.java
+++ b/src/org/jgroups/raft/filelog/LogEntryStorage.java
@@ -204,8 +204,17 @@ public class LogEntryStorage {
    }
 
    public void removeOld(int index) throws IOException {
-      fileStorage.truncateFrom(positionCache.getPosition(index));
+      int indexToRemove = Math.min(lastAppended, index);
+      long pos = positionCache.getPosition(indexToRemove);
+      if (pos > 0) {
+         // if pos is < 0, means the entry does not exist
+         // if pos == 0, means there is nothing to truncate
+         fileStorage.truncateFrom(pos);
+      }
       positionCache = positionCache.createDeleteCopyFrom(index);
+      if (lastAppended < index) {
+         lastAppended = index;
+      }
    }
 
    public int removeNew(int index) throws IOException {

--- a/src/org/jgroups/raft/util/LogCache.java
+++ b/src/org/jgroups/raft/util/LogCache.java
@@ -148,6 +148,7 @@ public class LogCache implements Log {
         cache.dropHeadUntil(index);
         // todo: first_appended should be set to the return value of truncate() (once it has been changed)
         first_appended=log.firstAppended();
+        last_appended = log.lastAppended();
     }
 
     public void deleteAllEntriesStartingFrom(int start_index) {

--- a/tests/junit-functional/org/jgroups/tests/SynchronousTests.java
+++ b/tests/junit-functional/org/jgroups/tests/SynchronousTests.java
@@ -1,7 +1,21 @@
 package org.jgroups.tests;
 
-import org.jgroups.*;
-import org.jgroups.protocols.raft.*;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.jgroups.Address;
+import org.jgroups.BytesMessage;
+import org.jgroups.Global;
+import org.jgroups.Message;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.AppendEntriesRequest;
+import org.jgroups.protocols.raft.AppendResult;
+import org.jgroups.protocols.raft.FileBasedLog;
+import org.jgroups.protocols.raft.LevelDBLog;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.RaftImpl;
 import org.jgroups.raft.testfwk.RaftCluster;
 import org.jgroups.raft.testfwk.RaftNode;
 import org.jgroups.raft.util.CommitTable;
@@ -11,11 +25,8 @@ import org.jgroups.util.ExtendedUUID;
 import org.jgroups.util.Util;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Same as {@link RaftTest}, but only a single thread is used to run the tests (no asynchronous processing).
@@ -24,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * @author Bela Ban
  * @since  1.0.5
  */
-@Test(groups=Global.FUNCTIONAL,singleThreaded=true)
+@Test(groups=Global.FUNCTIONAL,singleThreaded=true,dataProvider="logProvider")
 public class SynchronousTests {
     protected final Address       a=createAddress("A"), b=createAddress("B"), c=createAddress("C");
     protected View                view;
@@ -34,11 +45,22 @@ public class SynchronousTests {
     protected RaftNode            node_a, node_b, node_c;
     protected CounterStateMachine sma, smb, smc;
     protected static final int    TERM=5;
+    private String logClass;
 
-    @BeforeMethod protected void init() throws Exception {
+    @DataProvider
+    static Object[][] logProvider() {
+        return new Object[][] {
+              {LevelDBLog.class.getCanonicalName()},
+              {FileBasedLog.class.getCanonicalName()}
+        };
+    }
+
+    @BeforeMethod protected void init(Object[] args) throws Exception {
+        // args is the arguments from each test method
+        logClass = (String) args[0];
         view=View.create(a, 1, a,b);
-        raft_a=createRAFT(a, "A", mbrs).stateMachine(sma=new CounterStateMachine()).setLeaderAndTerm(a);
-        raft_b=createRAFT(b, "B", mbrs).stateMachine(smb=new CounterStateMachine()).setLeaderAndTerm(a);
+        raft_a=createRAFT(a, "A", mbrs).stateMachine(sma=new CounterStateMachine()).setLeaderAndTerm(a).logClass(logClass);
+        raft_b=createRAFT(b, "B", mbrs).stateMachine(smb=new CounterStateMachine()).setLeaderAndTerm(a).logClass(logClass);
         node_a=new RaftNode(cluster, raft_a);
         node_b=new RaftNode(cluster, raft_b);
         node_a.init();
@@ -71,7 +93,7 @@ public class SynchronousTests {
     }
 
 
-    public void testSimpleAppend() throws Exception {
+    public void testSimpleAppend(String logClass) throws Exception {
         int prev_value=add(1);
         assert prev_value == 0;
         assert sma.counter() == 1;
@@ -84,7 +106,7 @@ public class SynchronousTests {
     }
 
 
-    public void testRegularAppend() throws Exception {
+    public void testRegularAppend(String logClass) throws Exception {
         int prev_value=add(1);
         expect(0, prev_value);
         assert sma.counter() == 1;
@@ -142,7 +164,7 @@ public class SynchronousTests {
     }
 
 
-    public void testAppendSameElementTwice() throws Exception {
+    public void testAppendSameElementTwice(String logClass) throws Exception {
         raft_a.currentTerm(20);
         for(int i=1; i <= 5; i++)
             add(1);
@@ -163,7 +185,7 @@ public class SynchronousTests {
         assert smb.counter() == 5;
     }
 
-    public void testAppendBeyondLast() throws Exception {
+    public void testAppendBeyondLast(String logClass) throws Exception {
         raft_a.currentTerm(22);
         for(int i=1; i <= 5; i++)
             add(1);
@@ -180,7 +202,7 @@ public class SynchronousTests {
     }
 
     /** Tests appding with correct prev_index, but incorrect term */
-    public void testAppendWrongTerm() throws Exception {
+    public void testAppendWrongTerm(String logClass) throws Exception {
         raft_a.currentTerm(22);
         for(int i=1; i <= 15; i++) {
             if(i % 5 == 0)
@@ -235,7 +257,7 @@ public class SynchronousTests {
 
 
     /** Tests appends where we change prev_term, so that we'll get an AppendResult with success=false */
-    public void testIncorrectAppend() throws Exception {
+    public void testIncorrectAppend(String logClass) throws Exception {
         int prev_value=add(1);
         assert prev_value == 0;
         assert sma.counter() == 1;
@@ -290,7 +312,7 @@ public class SynchronousTests {
 
 
     /** Tests appending with correct prev_index, but incorrect term */
-    public void testAppendWrongTermOnlyOneTerm() throws Exception {
+    public void testAppendWrongTermOnlyOneTerm(String logClass) throws Exception {
         raft_a.currentTerm(22);
         for(int i=1; i <= 5; i++)
             add(1);
@@ -319,7 +341,7 @@ public class SynchronousTests {
         assertCommitTableIndeces(b, raft_a, 5, 5, 6);
     }
 
-    public void testSnapshot() throws Exception {
+    public void testSnapshot(String logClass) throws Exception {
         raft_b.maxLogSize(100);
         for(int i=1; i <= 100; i++) {
             add(i);
@@ -343,7 +365,7 @@ public class SynchronousTests {
     }
 
     /** Tests adding C to cluster A,B, transfer of state from A to C */
-    public void testAddThirdMember() throws Exception {
+    public void testAddThirdMember(String logClass) throws Exception {
         raft_a.currentTerm(20);
         for(int i=1; i <= 5; i++)
             add(i);
@@ -365,7 +387,7 @@ public class SynchronousTests {
     /** Members A,B,C: A and B have commit-index=10, B still has 5. A now snapshots its log at 10, but needs to
      * resend messages missed by C and cannot find them; therefore a snapshot is sent from A -> C
      */
-    public void testSnapshotOnLeader() throws Exception {
+    public void testSnapshotOnLeader(String logClass) throws Exception {
         raft_a.currentTerm(20);
         addMemberC();
         for(int i=1; i <= 5; i++)
@@ -408,7 +430,7 @@ public class SynchronousTests {
     }
 
 
-    public void testSnapshotOnFollower() throws Exception {
+    public void testSnapshotOnFollower(String logClass) throws Exception {
         raft_a.currentTerm(20);
         for(int i=1; i <= 5; i++)
             add(i);
@@ -522,7 +544,7 @@ public class SynchronousTests {
     }
 
     protected void addMemberC() throws Exception {
-        raft_c=createRAFT(c, "C", mbrs).stateMachine(smc=new CounterStateMachine()).setLeaderAndTerm(a);
+        raft_c=createRAFT(c, "C", mbrs).stateMachine(smc=new CounterStateMachine()).setLeaderAndTerm(a).logClass(logClass);
         node_c=new RaftNode(cluster, raft_c);
         node_c.init();
         node_c.start();


### PR DESCRIPTION
Removed "dummy" log entry and changed truncate() to update the
 "last-appender" index

---

Snapshot installation was performing the following steps:
* apply snapshot to the state machine
* create a new snapshot (truncates the log)
* append dummy log entry
* update the commit index
* truncate the log (again)

This pull request changes it and does the following
* apply the snapshot to the state machine
* update commit index
* create a new snapshot (truncates the log)

In order to make it work, I changed the `truncate()` method to update the `last-appended` index.

I changed the `SynchronousTests` to use both level-db and file-log. I was able to reproduce the error from https://github.com/belaban/jgroups-raft/pull/142#issuecomment-1102792973 and fix it.

@belaban @franz1981 let me know if it fixes the issue in your tests