### PR TITLE
CounterPerf benchmark for asynchronous counters

### DIFF
--- a/src/org/jgroups/perf/AsyncCounterBenchmark.java
+++ b/src/org/jgroups/perf/AsyncCounterBenchmark.java
@@ -1,0 +1,95 @@
+package org.jgroups.perf;
+
+import org.jgroups.blocks.atomic.AsyncCounter;
+import org.jgroups.util.AverageMinMax;
+import org.jgroups.util.CompletableFutures;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+
+/**
+ * Basic {@link org.jgroups.blocks.atomic.AsyncCounter} benchmark
+ */
+public class AsyncCounterBenchmark implements CounterBenchmark {
+
+    private List<CompletionStage<Void>> requests;
+    private LongSupplier deltaSupplier;
+    private int concurrency;
+    private AsyncCounter counter;
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+    private final LongAdder updates = new LongAdder();
+    private final AverageMinMax updateTimes = new AverageMinMax();
+
+    @Override
+    public void init(int concurrency, ThreadFactory threadFactory, LongSupplier deltaSupplier, AsyncCounter counter) {
+        this.concurrency = concurrency;
+        this.deltaSupplier = deltaSupplier;
+        this.counter = counter;
+        requests = new ArrayList<>(concurrency);
+    }
+
+    @Override
+    public void start() {
+        stop.set(false);
+        final long currentTime = System.nanoTime();
+        for (int i = 0; i < concurrency; ++i) {
+            requests.add(updateCounter(counter, currentTime));
+        }
+    }
+
+    @Override
+    public void stop() {
+        stop.set(true);
+    }
+
+    @Override
+    public void join() throws InterruptedException {
+        for (CompletionStage<Void> stage : requests) {
+            stage.toCompletableFuture().join();
+        }
+    }
+
+    @Override
+    public long getTotalUpdates() {
+        return updates.sum();
+    }
+
+    @Override
+    public AverageMinMax getResults(boolean printUpdaters, Function<AverageMinMax, String> timePrinter) {
+        synchronized (updateTimes) {
+            return updateTimes;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        stop.set(true);
+        requests.clear();
+    }
+
+    private void updateTime(long timeNanos) {
+        updates.increment();
+        synchronized (updateTimes) {
+            // AverageMinMax is not thread safe!
+            updateTimes.add(timeNanos);
+        }
+    }
+
+    private CompletionStage<Void> updateCounter(AsyncCounter counter, long start) {
+        if (stop.get()) {
+            // we don't check the return value
+            return CompletableFutures.completedNull();
+        }
+        return counter.addAndGet(deltaSupplier.getAsLong()).thenCompose(__ -> {
+            final long currentTime = System.nanoTime();
+            updateTime(currentTime - start);
+            return updateCounter(counter, currentTime);
+        });
+    }
+}


### PR DESCRIPTION
A simple/basic benchmark implementation. @belaban @franz1981 
We probably should implement other types of benchmarks as well (fixed rate? mixed add/gets?)

Local results:

With sync
```
done (in 30021 ms)

======================= Results: ===========================
B: 95,796.26 updates/sec (2,875,229 updates, 1.04ms / update)
A: 104,972.12 updates/sec (3,151,368 updates, 952.24us / update)
C: 94,767.64 updates/sec (2,845,588 updates, 1.05ms / update)


Throughput: 98,511.97 updates/sec/node
Time:       1.02ms / update




[1] Start test [2] View [4] Threads (100) [6] Time (30ms) [r] Range (10)
[t] incr timeout (1m) [d] details (false)  [i] print updaters (false)
[b] benchmark mode (sync)
[v] Version [x] Exit [X] Exit all  (counter=1892132)
```

With async 
```
done (in 30049 ms)

======================= Results: ===========================
A: 128,659.86 updates/sec (3,866,100 updates, 776.65us / update)
C: 116,339.77 updates/sec (3,502,176 updates, 858.81us / update)
B: 114,725.56 updates/sec (3,454,272 updates, 870.79us / update)


Throughput: 119,902.82 updates/sec/node
Time:       842.36us / update




[1] Start test [2] View [4] Threads (100) [6] Time (30ms) [r] Range (10)
[t] incr timeout (1m) [d] details (false)  [i] print updaters (false)
[b] benchmark mode (async)
[v] Version [x] Exit [X] Exit all  (counter=2365855)
```