### PR TITLE
Add HdrHistogram to record latency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -24,6 +24,7 @@
         <dependency org="org.openjdk.jmh"           name="jmh-generator-annprocess" rev="1.34"/>
         <dependency org="io.mashona"                name="mashona-logwriting"       rev="1.1.0"/>
         <dependency org="org.jboss.logging"         name="jboss-logging"            rev="3.4.1.Final"/>
+        <dependency org="org.hdrhistogram"          name="HdrHistogram"             rev="2.1.12"/>
 
     </dependencies>
 </ivy-module>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,12 @@
             <version>${mashona.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>2.1.12</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/src/org/jgroups/perf/CounterBenchmark.java
+++ b/src/org/jgroups/perf/CounterBenchmark.java
@@ -1,5 +1,7 @@
 package org.jgroups.perf;
 
+import org.HdrHistogram.AbstractHistogram;
+import org.HdrHistogram.Histogram;
 import org.jgroups.blocks.atomic.AsyncCounter;
 import org.jgroups.blocks.atomic.SyncCounter;
 import org.jgroups.util.AverageMinMax;
@@ -53,8 +55,9 @@ public interface CounterBenchmark extends AutoCloseable {
      * Returns the results of the run.
      *
      * @param printUpdaters If supported and if {@code true}, print to {@link System#out} each updater result.
-     * @param timePrinter   {@link Function} to use to print each updater {@link AverageMinMax} result.
-     * @return The {@link AverageMinMax} with the results of all updaters.
+     * @param timePrinter   {@link Function} to use to print each updater {@link AbstractHistogram} result.
+     * @return The {@link Histogram} with the results of all updaters.
      */
-    AverageMinMax getResults(boolean printUpdaters, Function<AverageMinMax, String> timePrinter);
+    Histogram getResults(boolean printUpdaters, Function<AbstractHistogram, String> timePrinter);
+
 }

--- a/src/org/jgroups/perf/HistogramUtil.java
+++ b/src/org/jgroups/perf/HistogramUtil.java
@@ -1,0 +1,38 @@
+package org.jgroups.perf;
+
+import org.HdrHistogram.AbstractHistogram;
+import org.HdrHistogram.AtomicHistogram;
+import org.HdrHistogram.Histogram;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility methods to create histograms and write the logs to file
+ */
+public enum HistogramUtil {
+    ;
+
+    // highest latency observable
+    private static final long HIGHEST_TRACKABLE_VALUE = TimeUnit.MINUTES.toNanos(1);
+    // precision between 0 and 5
+    private static final int PRECISION = 3;
+
+    public static Histogram create() {
+        return new Histogram(HIGHEST_TRACKABLE_VALUE, PRECISION);
+    }
+
+    public static AtomicHistogram createAtomic() {
+        return new AtomicHistogram(HIGHEST_TRACKABLE_VALUE, PRECISION);
+    }
+
+    public static void writeTo(AbstractHistogram histogram, File file) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            //change scale from nanos -> micros
+            histogram.outputPercentileDistribution(new PrintStream(out), 1000.0);
+        }
+    }
+}


### PR DESCRIPTION
* All benchmarks record the latency into HdrHistogram
* New option: "-histogram /path/to/save" when set, it stores the logs
  in that folder. You can create plots from the logs with an external
  tool.