### PR TITLE
Remove CompletableFutures#completeExceptionally

### DIFF
--- a/src/org/jgroups/raft/blocks/CounterService.java
+++ b/src/org/jgroups/raft/blocks/CounterService.java
@@ -306,7 +306,7 @@ public class CounterService implements StateMachine, RAFT.RoleChange {
             Bits.writeLongCompressed(value, out);
             return setAsyncWithTimeout(out, opts).thenApply(CounterService::readLong);
         } catch (Exception ex) {
-            return CompletableFutures.completeExceptionally(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 
@@ -316,7 +316,7 @@ public class CounterService implements StateMachine, RAFT.RoleChange {
             writeCommandAndName(out, command.ordinal(), name);
             return setAsyncWithTimeout(out, opts).thenApply(CounterService::readLong);
         } catch (Exception ex) {
-            return CompletableFutures.completeExceptionally(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 
@@ -327,7 +327,7 @@ public class CounterService implements StateMachine, RAFT.RoleChange {
             Bits.writeLongCompressed(arg, out);
             return setAsyncWithTimeout(out, opts).thenApply(CounterService::readLong);
         } catch (Exception ex) {
-            return CompletableFutures.completeExceptionally(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 
@@ -338,7 +338,7 @@ public class CounterService implements StateMachine, RAFT.RoleChange {
             Bits.writeLongCompressed(arg, out);
             return setAsyncWithTimeout(out, default_options).thenApply(CompletableFutures.toVoidFunction());
         } catch (Exception ex) {
-            return CompletableFutures.completeExceptionally(ex);
+            return CompletableFuture.failedFuture(ex);
         }
     }
 

--- a/src/org/jgroups/util/CompletableFutures.java
+++ b/src/org/jgroups/util/CompletableFutures.java
@@ -73,12 +73,6 @@ public enum CompletableFutures {
         return (Consumer<T>) VOID_CONSUMER;
     }
 
-    public static <T> CompletionStage<T> completeExceptionally(Throwable throwable) {
-        CompletableFuture<T> cf = new CompletableFuture<>();
-        cf.completeExceptionally(throwable);
-        return cf;
-    }
-
     public static CompletionException wrapAsCompletionException(Throwable throwable) {
         return throwable instanceof CompletionException ?
                 (CompletionException) throwable :


### PR DESCRIPTION
Closes #181

Method not longer required since it is provided by the JDK