### PR TITLE
Small fixes for REDIRECT and FileBasedLog

### DIFF
--- a/src/org/jgroups/protocols/raft/FileBasedLog.java
+++ b/src/org/jgroups/protocols/raft/FileBasedLog.java
@@ -238,6 +238,11 @@ public class FileBasedLog implements Log {
    @Override
    public void truncate(long index_exclusive) {
       assert index_exclusive >= firstAppended();
+
+      if (index_exclusive > commitIndex) {
+         index_exclusive=commitIndex;
+      }
+
       try {
          checkLogEntryStorageStarted().removeOld(index_exclusive);
       } catch (IOException e) {

--- a/src/org/jgroups/protocols/raft/REDIRECT.java
+++ b/src/org/jgroups/protocols/raft/REDIRECT.java
@@ -261,7 +261,7 @@ public class REDIRECT extends Protocol implements Settable, DynamicMembership {
         protected RequestType type;
         protected int         corr_id;   // correlation ID at the sender, so responses can unblock requests (keyed by ID)
         protected boolean     exception; // true if RSP is an exception
-        protected Options     options=Options.DEFAULT_OPTIONS;
+        protected Options     options=new Options();
 
         public RedirectHeader() {}
 

--- a/tests/junit-functional/org/jgroups/tests/LogTest.java
+++ b/tests/junit-functional/org/jgroups/tests/LogTest.java
@@ -281,6 +281,21 @@ public class LogTest {
         assertEquals(log.firstAppended(), 8);
     }
 
+    public void testTruncateOnlyCommitted(Log log) throws Exception {
+        this.log=log;
+        log.init(filename, null);
+        byte[] buf=new byte[10];
+        LogEntries le=new LogEntries();
+        for(int i=1; i <= 10; i++)
+            le.add(new LogEntry(5, buf));
+        log.append(1, le);
+
+        log.commitIndex(5);
+        log.truncate(10);
+        assertEquals(log.commitIndex(), 5);
+        assertEquals(log.firstAppended(), 5);
+    }
+
     public void testReinitializeTo(Log log) throws Exception {
         this.log=log;
         log.init(filename, null);


### PR DESCRIPTION
Just a couple of bug fixes. 

The first one was caught in `CounterTest`. When changing the `Options` and sending it, the `REDIRECT` would end up changing the `Options#DEFAULT_OPTIONS` so subsequent uses would not have the default options. For example, in the test case, the counter's get operation would not return the value because the default options changed.

The second changes the `FileBasedLog#truncate(long)` to comply with the javadoc, or in other words, only truncate up to the committed index.