### PR TITLE
Store the internal state in the snapshot.

### DIFF
--- a/src/org/jgroups/protocols/raft/Follower.java
+++ b/src/org/jgroups/protocols/raft/Follower.java
@@ -7,6 +7,7 @@ import org.jgroups.raft.StateMachine;
 import org.jgroups.util.ByteArrayDataInputStream;
 import org.jgroups.util.Util;
 
+import java.io.DataInput;
 import java.nio.ByteBuffer;
 
 /**
@@ -30,7 +31,10 @@ public class Follower extends RaftImpl {
             // Read into state machine
             ByteBuffer sn=ByteBuffer.wrap(msg.getArray(), msg.getOffset(), msg.getLength());
             raft.log().setSnapshot(sn);
-            sm.readContentFrom(new ByteArrayDataInputStream(msg.getArray(), msg.getOffset(), msg.getLength()));
+
+            DataInput in=new ByteArrayDataInputStream(msg.getArray(), msg.getOffset(), msg.getLength());
+            raft._internal_state.readFrom(in);
+            sm.readContentFrom(in);
 
             // insert a dummy entry at last_included_index and set first/last/commit to it
             Log log=raft.log();

--- a/src/org/jgroups/protocols/raft/PersistentState.java
+++ b/src/org/jgroups/protocols/raft/PersistentState.java
@@ -1,0 +1,64 @@
+package org.jgroups.protocols.raft;
+
+import org.jgroups.Global;
+import org.jgroups.util.SizeStreamable;
+import org.jgroups.util.Util;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Responsible for a node's internal state.
+ *
+ * <p>The data in this class is serialized and stored at the beginning of a snapshot file. This class does not
+ * hold information that the {@link RAFT} protocol requires to be persistent, e.g., terms and votes.</p>
+ *
+ * @author Jose Bolina
+ * @since 1.0.11
+ */
+public class PersistentState implements SizeStreamable {
+    private final List<String> members = new ArrayList<>();
+
+    public List<String> getMembers() {
+        return new ArrayList<>(members);
+    }
+
+    public void setMembers(Collection<String> value) {
+        members.clear();
+        members.addAll(new HashSet<>(value));
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+        int size=members.size();
+        out.writeInt(size);
+        for (String member : members) {
+            out.writeUTF(member);
+        }
+    }
+
+    @Override
+    public void readFrom(DataInput in) throws IOException {
+        int size=in.readInt();
+        List<String> tmp = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            tmp.add(in.readUTF());
+        }
+        setMembers(tmp);
+    }
+
+    @Override
+    public int serializedSize() {
+        int size=Global.INT_SIZE;
+        for (String member : members) {
+            size += Util.size(member);
+        }
+        return size;
+    }
+}


### PR DESCRIPTION
* Created a class to hold the node's internal state and serialize. Right now, it has only the members of the protocol.

* Store the internal state in the snapshot.

---

A step towards solving #189.

This is just a first (simpler) approach, storing the information at the beginning of the snapshot. It has the problem that can not parse snapshots of previous versions.

Another approach I can see is, to avoid that problem, we can create a separate structure working the same way as the snapshot right now, but only to the node's state.

Another thing, after we decide above, I want to add a byte to introduce a parser version to the snapshot to make it easier to handle future changes.