### PR TITLE
InMemoryLog fixes

### DIFF
--- a/src/org/jgroups/protocols/raft/InMemoryLog.java
+++ b/src/org/jgroups/protocols/raft/InMemoryLog.java
@@ -1,56 +1,55 @@
 package org.jgroups.protocols.raft;
 
 import org.jgroups.Address;
+import org.jgroups.raft.util.ArrayRingBuffer;
+import org.jgroups.raft.util.RWReference;
+
+import net.jcip.annotations.ThreadSafe;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ObjLongConsumer;
 
 /**
- * In-memory log implementation without any persistence. Used only by unit tests. Note that synchronization is
- * half-baked.
+ * An in-memory {@link Log} implementation without any persistence.
+ * <p>
+ * This implementation holds the log metadata behind a read-write lock. The actual {@link LogEntry} are stored
+ * with a {@link ArrayRingBuffer}, resizing as necessary. The entries are only freed from memory on a
+ * {@link Log#truncate(long)} operation, so it needs a proper configuration to avoid OOM.
+ * <p>
+ * <b>Warning:</b> This implementation does <b>not</b> tolerate restarts, meaning all internal states
+ * <b>will be lost</b>. If data must survive restarts, use another implementation.
+ *
  * @author Bela Ban
  * @since  0.2
+ * @see Log
  */
+@ThreadSafe
 public class InMemoryLog implements Log {
-    protected String       name; // the name of this log
-    protected long         current_term;
-    protected Address      voted_for;
-    protected long         first_appended;
-    protected long         last_appended;
-    protected long         commit_index;
-    protected LogEntry[]   entries;
-    protected ByteBuffer   snapshot;
-
     // keeps all logs, keyed by name
     public static final Map<String,Log> logs=new ConcurrentHashMap<>();
-    protected static final int          INCR=16; // always increase entries by 16 when needed
+    private final RWReference<LogMetadata> metadata = new RWReference<>(new LogMetadata());
 
+    protected String                name; // the name of this log
+    protected volatile Address      voted_for;
+    protected volatile ByteBuffer   snapshot;
 
-    public InMemoryLog() {
-    }
+    public InMemoryLog() { }
 
     @Override
     public void init(String log_name, Map<String,String> args) throws Exception {
         name=log_name;
         InMemoryLog existing=(InMemoryLog)logs.putIfAbsent(name, this);
         if(existing != null) {
-            current_term=existing.current_term;
             voted_for=existing.voted_for;
-            first_appended=existing.first_appended;
-            last_appended=existing.last_appended;
-            commit_index=existing.commit_index;
-            entries=existing.entries;
+            metadata.write(curr -> {
+                existing.metadata.read(curr::copy);
+            });
         }
         else {
-            current_term=0;
             voted_for=null;
-            first_appended=0;
-            last_appended=0;
-            commit_index=0;
-            entries=new LogEntry[16];
         }
     }
 
@@ -67,38 +66,43 @@ public class InMemoryLog implements Log {
 
     @Override
     public void delete() {
-        logs.remove(name);
+        InMemoryLog l = (InMemoryLog) logs.remove(name);
+        if (l != null) {
+            l.metadata.write(LogMetadata::delete);
+        }
     }
 
     @Override
-    public long currentTerm() {return current_term;}
+    public long currentTerm() {return metadata.read(m -> m.current_term);}
 
     @Override
-    public synchronized Log currentTerm(long new_term) {
-        current_term=new_term; return this;
+    public Log currentTerm(long new_term) {
+        metadata.write(m -> {m.current_term=new_term;});
+        return this;
     }
 
     @Override
     public Address votedFor() {return voted_for;}
 
     @Override
-    public synchronized Log votedFor(Address member) {
+    public Log votedFor(Address member) {
         voted_for=member; return this;
     }
 
     @Override
-    public long commitIndex() {return commit_index;}
+    public long commitIndex() {return metadata.read(m -> m.commit_index);}
 
     @Override
-    public synchronized Log commitIndex(long new_index) {
-        commit_index=new_index; return this;
+    public Log commitIndex(long new_index) {
+        metadata.write(m -> { m.commit_index=new_index; });
+        return this;
     }
 
     @Override
-    public long firstAppended() {return first_appended;}
+    public long firstAppended() {return metadata.read(m -> m.first_appended);}
 
     @Override
-    public long lastAppended() {return last_appended;}
+    public long lastAppended() {return metadata.read(m -> m.last_appended);}
 
 
     public void setSnapshot(ByteBuffer sn) {
@@ -110,111 +114,141 @@ public class InMemoryLog implements Log {
     }
 
     @Override
-    public synchronized long append(long index, LogEntries entries) {
-        int space_required=entries != null? entries.size() : 0;
-        long available_space=this.entries.length - 1 - last_appended;
-        if(space_required > available_space)
-            expand((int)(space_required - available_space +1));
-
-        for(LogEntry entry: entries) {
-            int idx=(int)(index-first_appended); // we cannot be more than 2^31 (max size of int) apart!
-            this.entries[idx]=entry;
-            last_appended=Math.max(last_appended, index);
-            index++;
-            if(entry.term > current_term)
-                current_term=entry.term;
+    public long append(long index, LogEntries entries) {
+        LogEntry[] elements = entries.entries.toArray(new LogEntry[entries.size()]);
+        long term = 0;
+        for (int i = 0; i < entries.size(); i++) {
+            LogEntry entry = entries.entries.get(i);
+            if (entry.term > term) term = entry.term;
         }
-        return last_appended;
+
+        long candidate_term = term;
+        long candidate_last = index + entries.size() - 1;
+        return metadata.write(m -> {
+            for (LogEntry entry : elements) m.entries.add(entry);
+            m.last_appended=Math.max(m.last_appended, candidate_last);
+            m.current_term=Math.max(m.current_term, candidate_term);
+            return m.last_appended;
+        });
     }
 
 
     @Override
-    public synchronized LogEntry get(long index) {
-        int real_index=(int)(index - first_appended);
-        return real_index < 0 || real_index >= entries.length? null : entries[real_index];
+    public LogEntry get(long index) {
+        if (index <= 0) return null;
+
+        return metadata.read(m -> {
+            int real_index=(int)(index - m.first_appended);
+            return real_index < 0 || m.entries.isEmpty() || real_index > m.entries.size() ? null : m.entries.get(index);
+        });
     }
 
     @Override
-    public synchronized void truncate(long index_exclusive) {
-        if(index_exclusive > commit_index)
-            index_exclusive=commit_index;
-        LogEntry[] tmp=new LogEntry[entries.length];
-        int idx=(int)(index_exclusive - first_appended);
-        System.arraycopy(entries, idx, tmp, 0, entries.length - idx);
-        entries=tmp;
-        first_appended=index_exclusive;
-        if (last_appended < index_exclusive) {
-            last_appended =index_exclusive;
-        }
+    public void truncate(long index_exclusive) {
+        metadata.write(m -> {
+            long actual_index = Math.min(index_exclusive, m.commit_index);
+            m.entries.dropHeadUntil(actual_index);
+            m.first_appended=actual_index;
+            if (m.last_appended < actual_index) {
+                m.last_appended =actual_index;
+            }
+        });
     }
 
     @Override
     public void reinitializeTo(long index, LogEntry entry) {
-        Arrays.fill(entries, null);
-        first_appended=commit_index=last_appended=index;
-        current_term=entry.term();
+        metadata.write(m -> {
+            m.current_term=entry.term();
+            m.entries.dropHeadUntil(index);
+            m.entries.dropTailToHead();
+            m.first_appended=m.commit_index=m.last_appended=index;
+        });
     }
 
     @Override
-    public synchronized void deleteAllEntriesStartingFrom(long start_index) {
-        int idx=(int)(start_index- first_appended);
-        if(idx < 0 || idx >= entries.length)
-            return;
+    public void deleteAllEntriesStartingFrom(long start_index) {
+        metadata.write(m -> {
+            int idx=(int)(start_index- m.first_appended);
+            if(idx < 0 || idx > m.entries.size())
+                return;
 
-        assert start_index > commit_index; // the commit index cannot go back!
+            assert start_index > m.commit_index; // the commit index cannot go back!
 
-        for(int index=idx; index <= last_appended; index++)
-            entries[index]=null;
-
-        LogEntry last=get(start_index - 1);
-        current_term=last != null? last.term : 0;
-        last_appended=start_index-1;
-        if(commit_index > last_appended)
-            commit_index=last_appended;
+            m.entries.dropTailTo(start_index);
+            LogEntry last=get(start_index - 1);
+            m.current_term=last != null? last.term : 0;
+            m.last_appended=start_index-1;
+            if(m.commit_index > m.last_appended)
+                m.commit_index=m.last_appended;
+        });
     }
 
     @Override
-    public synchronized void forEach(ObjLongConsumer<LogEntry> function, long start_index, long end_index) {
-        if(start_index < first_appended)
-            start_index=first_appended;
-        if(end_index > last_appended)
-            end_index=last_appended;
+    public void forEach(ObjLongConsumer<LogEntry> function, long start_index, long end_index) {
+        metadata.read(m -> {
+            long start = Math.max(start_index, m.entries.getHeadSequence());
+            long end = Math.min(end_index, m.entries.getTailSequence());
 
-        int start=(int)(Math.max(1, start_index)- first_appended), end=(int)(end_index- first_appended);
-        for(int i=start; i <= end; i++) {
-            LogEntry entry=entries[i];
-            function.accept(entry, i);
-        }
+            for(long i=start; i < end; i++) {
+                LogEntry entry=m.entries.get(i);
+                function.accept(entry, i);
+            }
+        });
     }
 
     @Override
-    public synchronized void forEach(ObjLongConsumer<LogEntry> function) {
-        forEach(function, Math.max(1, first_appended), last_appended);
+    public void forEach(ObjLongConsumer<LogEntry> function) {
+        metadata.read(m -> {
+            forEach(function, Math.max(1, m.entries.getHeadSequence()), m.entries.getTailSequence());
+        });
     }
 
     public long sizeInBytes() {
-        long size=0;
-        int start_index=(int)Math.max(first_appended, 1);
-        for(int i=start_index; i <= last_appended; i++) {
-            LogEntry entry=entries[i];
-            if(entry != null)
-                size+=entry.length;
-        }
-        return size;
+        return metadata.read(m -> {
+            AtomicLong size = new AtomicLong(0);
+            m.entries.forEach((entry, ignore) -> size.addAndGet(entry.length));
+            return size.longValue();
+        });
     }
 
     @Override
     public String toString() {
         StringBuilder sb=new StringBuilder();
-        sb.append("first_appended=").append(first_appended).append(", last_appended=").append(last_appended)
-          .append(", commit_index=").append(commit_index).append(", current_term=").append(current_term);
-        return sb.toString();
+        return metadata.read(m -> {
+            sb.append("first_appended=").append(m.first_appended).append(", last_appended=").append(m.last_appended)
+                    .append(", commit_index=").append(m.commit_index).append(", current_term=").append(m.current_term);
+            return sb.toString();
+        });
     }
 
-    /** Lock must be held to call this method */
-    protected void expand(int min_size_needed) {
-        LogEntry[] new_entries=new LogEntry[Math.max(entries.length + INCR, entries.length + min_size_needed)];
-        System.arraycopy(entries, 0, new_entries, 0, entries.length);
-        entries=new_entries;
+    private static class LogMetadata {
+        private long                      current_term;
+        private long                      first_appended;
+        private long                      last_appended;
+        private long                      commit_index;
+        private ArrayRingBuffer<LogEntry> entries;
+
+        public LogMetadata() {
+            this.entries = new ArrayRingBuffer<>(16, 1);
+            this.current_term = 0;
+            this.first_appended = 0;
+            this.last_appended = 0;
+            this.commit_index = 0;
+        }
+
+        public void copy(LogMetadata other) {
+            this.current_term = other.current_term;
+            this.first_appended = other.first_appended;
+            this.last_appended = other.last_appended;
+            this.commit_index = other.commit_index;
+            this.entries = other.entries;
+        }
+
+        public void delete() {
+            this.current_term = 0;
+            this.first_appended = 0;
+            this.last_appended = 0;
+            this.commit_index = 0;
+        }
     }
 }

--- a/src/org/jgroups/raft/util/RWReference.java
+++ b/src/org/jgroups/raft/util/RWReference.java
@@ -1,0 +1,61 @@
+package org.jgroups.raft.util;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Holds an immutable object behind a {@link ReadWriteLock}. All accesses to the underlying object
+ * must acquire the proper lock. A simple approach to assert all access is executed through the same
+ * synchronization mechanism. The lock is reentrant.
+ * <p>
+ * The access to the object is either a read or write. Calling the correct method, the client can use
+ * a {@link Consumer} to access the object or a {@link Function} to compute a return value.
+ *
+ * @param <T> the type of object to hold.
+ */
+public class RWReference<T> {
+    private final ReadWriteLock lock;
+    private final T value;
+
+    public RWReference(T value) {
+        this.value = value;
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    public void read(Consumer<T> consumer) {
+        read(v -> {
+            consumer.accept(v);
+            return null;
+        });
+    }
+
+    public void write(Consumer<T> consumer) {
+        write(v -> {
+            consumer.accept(v);
+            return null;
+        });
+    }
+
+    public <V> V read(Function<T, V> function) {
+        Lock rl = lock.readLock();
+        try {
+            rl.lock();
+            return function.apply(value);
+        } finally {
+            rl.unlock();
+        }
+    }
+
+    public <V> V write(Function<T, V> function) {
+        Lock wl = lock.writeLock();
+        try {
+            wl.lock();
+            return function.apply(value);
+        } finally {
+            wl.unlock();
+        }
+    }
+}


### PR DESCRIPTION
Some fixes to the InMemoryLog, specifically concurrency and resizing mechanism. This should address #152 and #153.
Although this is a low priority, this is something I was playing with. And it might come in hand for the ISPN counters: 

https://github.com/infinispan/infinispan/blob/c2db1cc26bcebe2a4edc3ac583bda07948aa1fb8/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsRaftManager.java#L115-L119

All in all, it does pretty much the same thing as before but instead uses the ArrayRingBuffer and a read-write lock instead of synchronized blocks. For the synchronization part, I am a bit unsure if it is actually needed, as we consume messages in a single thread maybe we can get rid of the lock. But since I was not completely sure, I left it as is.

Running this version against main for the counter-perf we have:

```text
NEW:
======================= Results: ===========================
A: 168,343.58 updates/sec (20,203,587 updates, 593.72us / update)
B: 128,772.41 updates/sec (15,454,363 updates, 775.97us / update)


Throughput: 148,558.08 updates/sec/node
Time:       672.71us / update

MAIN:
======================= Results: ===========================
A: 10,831.18 updates/sec (1,300,879 updates, 9.22ms / update)
B: 9,998.01 updates/sec (1,201,111 updates, 10.00ms / update)


Throughput: 10,414.54 updates/sec/node
Time:       9.60ms / update
```

TBH these numbers make me think I did something wrong :sweat_smile:
But I consistently got values like these in multiple executions. I am running for 2 min, sync version, with 2 nodes. The leader has 3 cores and the follower has another 3 cores, so they shouldn't compete. I didn't run the LogJmhBenchmark for comparison between versions, as it is specific for appending entries I would expect both versions to have similar performance (another reason why the counter-perf makes me worried).

I ran it for 30min without OOM, and for 1 min capturing with JMC. Both leader and follower have a similar graph:

![image](https://user-images.githubusercontent.com/13581903/211958907-a0afff8a-8c6f-4a62-a7c7-7f866e9352c9.png)

This is definitely a low-priority PR but the counter-perf numbers made me think it could be worth opening the PR (as the changes aren't that big) or at least starting a discussion.