### PR TITLE
Configurable quorum get for `ReplicatedStateMachine`

### DIFF
--- a/src/org/jgroups/raft/demos/ProgrammaticRSM.java
+++ b/src/org/jgroups/raft/demos/ProgrammaticRSM.java
@@ -144,6 +144,11 @@ public class ProgrammaticRSM {
                 public void remove(String key, Object old_val) {
                     System.out.printf("-- remove(%s) -> %s\n", key, old_val);
                 }
+
+                @Override
+                public void get(String key, Object val) {
+                    System.out.printf("-- get(%s) -> %s\n", key, val);
+                }
             });
 
             rsm.addRoleChangeListener(role -> System.out.println("-- changed role to " + role));
@@ -271,8 +276,16 @@ public class ProgrammaticRSM {
     }
 
     protected static void get(String key) {
-        Object val=rsm.get(key);
-        System.out.printf("-- get(%s) -> %s\n", key, val);
+        if(key == null) {
+            System.err.printf("Key (%s) is null\n",key);
+            return;
+        }
+
+        try {
+            rsm.get(key);
+        } catch (Throwable t) {
+            System.err.println("failed getting " + key + ": " + t);
+        }
     }
 
     protected static void remove(String key) {

--- a/src/org/jgroups/raft/demos/ReplicatedStateMachineDemo.java
+++ b/src/org/jgroups/raft/demos/ReplicatedStateMachineDemo.java
@@ -52,6 +52,11 @@ public class ReplicatedStateMachineDemo implements org.jgroups.blocks.cs.Receive
             @Override public void remove(String key, Object old_val) {
                 System.out.printf("-- remove(%s) -> %s\n", key, old_val);
             }
+
+            @Override
+            public void get(String key, Object val) {
+                System.out.printf("-- get(%s) -> %s\n", key, val);
+            }
         });
         if(listen)
             start(bind_addr, port);
@@ -196,9 +201,13 @@ public class ReplicatedStateMachineDemo implements org.jgroups.blocks.cs.Receive
     }
 
     protected Object get(String key) {
-        Object val=rsm.get(key);
-        System.out.printf("-- get(%s) -> %s\n", key, val);
-        return val;
+        try {
+            return rsm.get(key);
+        } catch (Throwable t) {
+            String ret=String.format("failed getting %s: %s", key, t);
+            System.err.println(ret);
+            return ret;
+        }
     }
 
     protected Object remove(String key) {

--- a/tests/junit-functional/org/jgroups/tests/AppendEntriesTest.java
+++ b/tests/junit-functional/org/jgroups/tests/AppendEntriesTest.java
@@ -701,7 +701,7 @@ public class AppendEntriesTest {
         assert raft.isLeader();
     }
 
-    protected void assertPresent(int key, int value, ReplicatedStateMachine<Integer,Integer> ... rsms) {
+    protected void assertPresent(int key, int value, ReplicatedStateMachine<Integer,Integer> ... rsms) throws Exception {
         if(rsms == null || rsms.length == 0)
             rsms=new ReplicatedStateMachine[]{as,bs,cs};
         for(int i=0; i < 10; i++) {


### PR DESCRIPTION
* Add option for quorum get for ReplicateStateMachine. By default, it uses the quorum get, configurable to allow for stale reads.