### PR TITLE
Encapsulate part of RAFT state

### DIFF
--- a/src/org/jgroups/protocols/raft/state/RaftState.java
+++ b/src/org/jgroups/protocols/raft/state/RaftState.java
@@ -1,0 +1,200 @@
+package org.jgroups.protocols.raft.state;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.jgroups.Address;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.RAFT;
+
+import net.jcip.annotations.ThreadSafe;
+
+/**
+ * Keep track of part of the algorithm state. The state here is tightly synchronized and needs to be updated atomically.
+ * <p>
+ * Throughout the RAFT execution, the node updates the values for term, leader, and the election vote. The values need
+ * to be updated atomically, following the term transition. This synchronization is necessary for clients to perceive
+ * the same leaders and terms.
+ * <p>
+ * Utilizing both Ongaro's dissertation<sup>1</sup> and the original RAFT<sup>2</sup> article as the base. The relation
+ * of all these variables in the state may not be clear. Starting with the assertion that a term only starts through a
+ * new election. In other words, when updating the term, the leader is unknown. The term increases monotonically, and
+ * some nodes might skip it due to connectivity issues.
+ * <p>
+ * All messages carry the sender's current term. On receiving a message, nodes verify and update. Messages with older
+ * terms are discarded. A higher term causes the node to advance its term, set both the leader and vote to null, and
+ * proceed with the message processing.
+ * <p>
+ * The leader value only updates to the elected leader (null -> new leader) or to step down (leader -> null). Updating
+ * the leader directly to another throws an exception. The election vote follows the same logic.
+ * <p>
+ * In summary, the logic follows that updating to a received higher term sets the leader and vote to null. Later, when
+ * the leader is known, the update within the same term is accepted since the current term leader is still null.
+ *
+ * @author José Bolina
+ * @since 1.0.12
+ * @see <a href="https://github.com/ongardie/dissertation">1: Ongaro's dissertation</a>
+ * @see <a href="https://www.usenix.org/node/184041.">2: RAFT paper</a>
+ */
+@ThreadSafe
+public class RaftState {
+
+    private final RAFT raft;
+    private final Consumer<Address> onLeaderUpdate;
+    private Address leader;
+    private long term;
+    private Address votedFor;
+
+    public RaftState(RAFT raft, Consumer<Address> onLeaderUpdate) {
+        this.raft = raft;
+        this.onLeaderUpdate = onLeaderUpdate;
+        reload();
+    }
+
+    public synchronized Address leader() {
+        return leader;
+    }
+
+    public synchronized long currentTerm() {
+        return term;
+    }
+
+    public synchronized Address votedFor() {
+        return votedFor;
+    }
+
+    /**
+     * Advances the term for leader election.
+     * <p>
+     * This automatically sets the {@link #leader} and {@link #votedFor} to null.
+     * </p>
+     *
+     * @return The new term.
+     * @see #tryAdvanceTerm(long)
+     */
+    public long advanceTermForElection() {
+        while (true) {
+            long current = currentTerm();
+            if (tryAdvanceTerm(current + 1) == 1) {
+                return currentTerm();
+            }
+        }
+    }
+
+    /**
+     * Try advancing the term, and if succeeding, the leader is null.
+     *
+     * @param newTerm: The term to advance to.
+     * @return Has the same result as <code>Long.compare(newTerm, currentTerm());</code>.
+     * @see #tryAdvanceTermAndLeader(long, Address)
+     */
+    public int tryAdvanceTerm(long newTerm) {
+        return tryAdvanceTermAndLeader(newTerm, null);
+    }
+
+    /**
+     * Try to advance the current term and set the leader.
+     * <p>
+     * A lower term has no effect. A higher term updates the node's current term to {@param newTerm}, and the leader to
+     * {@param newLeader} and vote to <code>null</code>. The term and vote are written to disk.
+     *
+     * @param newTerm: New term to update to.
+     * @param newLeader: The leader to update in case the term advances.
+     * @return Has the same result as <code>Long.compare(newTerm, currentTerm());</code>. That is, -1 if the
+     *         <code>newTerm < currentTerm()</code>, 0 if both are equal, and 1 if <code>currentTerm()</code> is higher.
+     */
+    public int tryAdvanceTermAndLeader(long newTerm, Address newLeader) {
+        boolean saveVote = false;
+        boolean saveTerm = false;
+        synchronized (this) {
+            // Step down uses the term `0`. It does not update the term, only the leader to null.
+            if (newTerm > 0 && newTerm < term) return -1;
+            if (newTerm == term && newLeader == null) return 0;
+            if (newTerm > term) {
+                raft.getLog().trace("%s: changed term from %d -> %d", raft.addr(), term, newTerm);
+
+                term = newTerm;
+                saveTerm = true;
+                saveVote = setVotedFor(null, false);
+                // To not invoke the leader change listener twice.
+                this.leader = null;
+            }
+            setLeader(newLeader);
+        }
+
+        Log log = raft.log();
+        if (log != null) {
+            if (saveTerm) log.currentTerm(currentTerm());
+            if (saveVote) log.votedFor(votedFor());
+        }
+
+        return saveTerm ? 1 : 0;
+    }
+
+    /**
+     * Update the leader in the current term.
+     * <p>
+     * A leader can not change within the same term. The update only happens when a new leader is elected
+     * (null -> new leader) or when the leader steps down (current leader -> null).
+     *
+     * @param newLeader: The new leader to update to.
+     * @throws IllegalStateException: If trying to update between different leaders in the same term.
+     */
+    public synchronized void setLeader(Address newLeader) {
+        if (this.leader != null && newLeader != null && !Objects.equals(this.leader, newLeader))
+            throw new IllegalStateException(String.format("Changing leader %s to %s illegally", this.leader, newLeader));
+
+        boolean updated = newLeader == null || this.leader == null;
+        this.leader = newLeader;
+
+        // We only should invoke the listener when a new leader is set/step down.
+        if (updated) onLeaderUpdate.accept(this.leader);
+    }
+
+    /**
+     * Set the vote in the current term.
+     * <p>
+     * Follows the same logic as {@link #setLeader(Address)}. The vote is also written to disk.
+     *
+     * @param votedFor: The vote in the current term.
+     * @throws IllegalStateException: If trying to update between different votes within the same term.
+     */
+    public void setVotedFor(Address votedFor) {
+        setVotedFor(votedFor, true);
+    }
+
+    /**
+     * Read the state information from the {@link RAFT}'s log.
+     */
+    public void reload() {
+        Log log = raft.log();
+        if (log != null) {
+            synchronized (this) {
+                term = log.currentTerm();
+                votedFor = log.votedFor();
+            }
+        }
+    }
+
+    private boolean setVotedFor(Address votedFor, boolean save) {
+        synchronized (this) {
+            if (votedFor != null && this.votedFor != null && !Objects.equals(votedFor, this.votedFor))
+                throw new IllegalStateException(String.format("Changing vote %s to %s illegally", this.votedFor, votedFor));
+
+            // If it is the same object, returns null as there is no need to flush to disk.
+            if (Objects.equals(this.votedFor, votedFor)) return false;
+            this.votedFor = votedFor;
+        }
+
+        if (save) {
+            Log log = raft.log();
+            if (log != null) log.votedFor(votedFor());
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "[leader=" + leader + ", term=" + term + ", voted=" + votedFor + "]";
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/RaftTest.java
+++ b/tests/junit-functional/org/jgroups/tests/RaftTest.java
@@ -110,7 +110,7 @@ public class RaftTest {
         assertCommitTableIndeces(b.getAddress(), raft_a, 1003, 1004, 1005);
 
         long current_term=raft_a.currentTerm(), expected_term;
-        raft_a.currentTerm(expected_term=current_term + 10);
+        raft_a.setLeaderAndTerm(a.getAddress(), expected_term=current_term + 10);
 
         for(int i=1; i <= 7; i++)
             add(rha, 1);
@@ -125,7 +125,7 @@ public class RaftTest {
 
 
     public void testAppendSameElementTwice() throws Exception {
-        raft_a.currentTerm(20);
+        raft_a.setLeaderAndTerm(a.getAddress(), 20);
         for(int i=1; i <= 5; i++)
             add(rha, 1);
         assertIndices(5, 5, 20, raft_a);
@@ -146,7 +146,7 @@ public class RaftTest {
     }
 
     public void testAppendBeyondLast() throws Exception {
-        raft_a.currentTerm(22);
+        raft_a.setLeaderAndTerm(a.getAddress(), 22);
         for(int i=1; i <= 5; i++)
             add(rha, 1);
         assert sma.counter() == 5;
@@ -164,10 +164,10 @@ public class RaftTest {
 
     /** Tests appding with correct prev_index, but incorrect term */
     public void testAppendWrongTerm() throws Exception {
-        raft_a.currentTerm(22);
+        raft_a.setLeaderAndTerm(a.getAddress(), 22);
         for(int i=1; i <= 15; i++) {
             if(i % 5 == 0)
-                raft_a.currentTerm(raft_a.currentTerm()+1);
+                raft_a.setLeaderAndTerm(a.getAddress(), raft_a.currentTerm()+1);
             add(rha, 1);
         }
         expect(15, sma.counter());
@@ -191,12 +191,12 @@ public class RaftTest {
         long incorrect_prev_term=24;
         long commit_index=raft_a.commitIndex(), prev_index=18;
 
+        raft_a.setLeaderAndTerm(a.getAddress(), 30);
         sendAppendEntriesRequest(raft_a, prev_index, incorrect_prev_term, 30, commit_index);
         Util.sleep(1000); // nothing changed
         assertCommitTableIndeces(b.getAddress(), raft_a, 14, 14, 15);
 
         // now apply the updates on the leader
-        raft_a.currentTerm(30);
         raft_a.resendInterval(1000);
         for(int i=16; i <= 18; i++)
             add(rha, 1);
@@ -232,7 +232,7 @@ public class RaftTest {
         assertIndices(1, 0, 0, raft_b);
         assertCommitTableIndeces(b.getAddress(), raft_a, 0, 1, 2);
 
-        raft_a.currentTerm(2);
+        raft_a.setLeaderAndTerm(a.getAddress(), 2);
         prev_value=add(rha, 1);
         assert prev_value == 1;
         prev_value=add(rha, 1);
@@ -241,7 +241,7 @@ public class RaftTest {
         assert smb.counter() == 2; // previous value; B is always lagging one commit behind
         assertCommitTableIndeces(b.getAddress(), raft_a, 2, 3, 4);
 
-        raft_a.currentTerm(4);
+        raft_a.setLeaderAndTerm(a.getAddress(), 4);
         for(int i=1; i <= 3; i++)
             add(rha, 1);
 
@@ -265,7 +265,7 @@ public class RaftTest {
         assert result.success();
         assertIndices(8, 5, 5, raft_b);
 
-        raft_a.currentTerm(7);
+        raft_a.setLeaderAndTerm(a.getAddress(), 7);
         for(int i=1; i <= 2; i++)
             add(rha, -1);
 
@@ -283,7 +283,7 @@ public class RaftTest {
 
         raft_a.resendInterval(1000);
 
-        raft_a.currentTerm(22);
+        raft_a.setLeaderAndTerm(a.getAddress(), 22);
         for(int i=1; i <= 5; i++)
             add(rha, 1);
         expect(5, sma.counter());

--- a/tests/junit-functional/org/jgroups/tests/SyncLeaderCrashTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SyncLeaderCrashTest.java
@@ -141,12 +141,13 @@ public class SyncLeaderCrashTest {
 
         RAFT r=rafts[0];
         assert r.isLeader();
-        r.currentTerm(2);
+        Address leader = r.leader();
+        r.setLeaderAndTerm(leader, 2);
         r.set(DATA, 0, DATA.length, 5, TimeUnit.SECONDS);
-        r.currentTerm(5);
+        r.setLeaderAndTerm(leader, 5);
         r.set(DATA, 0, DATA.length, 5, TimeUnit.SECONDS);
         r.set(DATA, 0, DATA.length, 5, TimeUnit.SECONDS);
-        r.currentTerm(7);
+        r.setLeaderAndTerm(leader, 7);
         r.set(DATA, 0, DATA.length, 5, TimeUnit.SECONDS);
 
         System.out.printf("terms:\n%s\n", printTerms());


### PR DESCRIPTION
Fixes #218. It took some time to get everything. I was delving into the resources to understand what happens after the term is updated. Everything should be covered now. On term update:

* Reset the term's leader and vote;
* Step down already exists, but it seems the role changes weren't applied in all updates;

I was worried that the leader needed to handle responses with higher terms differently, but it seemed unnecessary. Added a small test that ensures the leader is reset when the term increases. This leads to a change in role, too. The commit includes:

* Encapsulate the current term, the leader, and vote together. These values are updated atomically. This maintains some of the leader election invariants.
* Advancing the term reset the leader and vote to null.
* Restrict the leader and vote updates within the same term.
* Updates the test to the way terms and leader is updated now.


