### PR TITLE
Adding ELECTION2 protocol

### DIFF
--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -1,119 +1,53 @@
 package org.jgroups.protocols.raft;
 
-import org.jgroups.*;
+import org.jgroups.Address;
+import org.jgroups.View;
 import org.jgroups.annotations.MBean;
-import org.jgroups.annotations.ManagedAttribute;
-import org.jgroups.annotations.Property;
-import org.jgroups.conf.AttributeType;
 import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.protocols.raft.election.BaseElection;
 import org.jgroups.raft.util.Utils;
 import org.jgroups.raft.util.Utils.Majority;
-import org.jgroups.stack.Protocol;
-import org.jgroups.util.MessageBatch;
-import org.jgroups.util.ResponseCollector;
-import org.jgroups.util.Runner;
 
-import java.util.*;
-
-import static org.jgroups.Message.Flag.OOB;
-import static org.jgroups.Message.TransientFlag.DONT_LOOPBACK;
+import java.util.List;
+import java.util.Objects;
 
 /**
- * Performs leader election. When coordinator, starts a voting thread which asks everyone to cast their votes. Stops
- * when a new leader has been elected.
+ * The default leader election algorithm.
+ * <p>
+ * Performs leader election. This implementation takes full advantage of JGroup's membership events with {@link View}.
+ * When the current node is the view coordinator, it starts a voting thread to ask all members to send their information.
+ * The voting thread stops when a new leader is elected.
+ * <p>
+ * The process that starts the voting thread is not trying to elect itself. The process running the voting process
+ * increases its term and asks all nodes about their term and log index information to select the new leader, in the
+ * form of {@link org.jgroups.protocols.raft.election.VoteResponse}. For safety reasons, only the nodes with the most
+ * up-to-date log can be elected a leader. With a response from the majority processes, the leader with the higher term
+ * and log index is elected. The oldest process (view coordinator) in the system has a priority. Once decided, the
+ * process sends a message reliably to everyone identifying the new leader, with the
+ * {@link org.jgroups.protocols.raft.election.LeaderElected} message.
+ * <p>
+ * After a leader is elected, a new election round starts on view changes only if the leader left the cluster. In case
+ * of losing a majority, the leader steps down.
+ * <p>
+ * This implementation is more robust than building with heartbeats, leading to fewer disruptions in the cluster with
+ * unnecessary (competing) election rounds. This also means the leader is capable of stepping down. Referred to in
+ * §6.2 of Ongaro's dissertation to prevent stale leadership information.
+ * <p>
+ * More information is available in the design docs.
+ *
  * @author Bela Ban
  * @since  0.1
+ * @see <a href="https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf">Ongaro's dissertation</a>
  */
 @MBean(description="Protocol performing leader election according to the RAFT paper")
-public class ELECTION extends Protocol {
+public class ELECTION extends BaseElection {
     protected static final short ELECTION_ID    = 520;
-    protected static final short VOTE_REQ       = 3000;
-    protected static final short VOTE_RSP       = 3001;
-    protected static final short LEADER_ELECTED = 3005;
 
     static {
         ClassConfigurator.addProtocol(ELECTION_ID, ELECTION.class);
-        ClassConfigurator.add(VOTE_REQ,      VoteRequest.class);
-        ClassConfigurator.add(VOTE_RSP,      VoteResponse.class);
-        ClassConfigurator.add(LEADER_ELECTED, LeaderElected.class);
-    }
-
-    @Property(description="Max time (ms) to wait for vote responses",type=AttributeType.TIME)
-    protected long               vote_timeout=600;
-    @ManagedAttribute(description="Number of voting rounds initiated by the coordinator")
-    protected int                num_voting_rounds;
-
-    protected RAFT               raft; // direct ref instead of events
-    protected volatile View      view;
-    protected final Runner       voting_thread=new Runner("voting-thread", this::runVotingProcess, null);
-
-    protected ResponseCollector<VoteResponse> votes=new ResponseCollector<>();
-
-    public long                            voteTimeout() {return vote_timeout;}
-    public RAFT                            raft()        {return raft;}
-    public ELECTION                        raft(RAFT r)  {raft=r; return this;}
-    public ResponseCollector<VoteResponse> getVotes()    {return votes;} // use for testing only!
-
-    public void resetStats() {
-        super.resetStats();
-        num_voting_rounds=0;
-    }
-
-    @ManagedAttribute(description="Is the voting thread (only on the coordinator) running?")
-    public boolean isVotingThreadRunning() {return voting_thread.isRunning();}
-
-    public void init() throws Exception {
-        super.init();
-        raft=findProtocol(RAFT.class);
-    }
-
-    public void stop() {
-        stopVotingThread();
-        raft.setLeaderAndTerm(null);
-    }
-
-    public Object down(Event evt) {
-        switch(evt.getType()) {
-            case Event.DISCONNECT:
-                raft.setLeaderAndTerm(null);
-                break;
-            case Event.VIEW_CHANGE:
-                handleView(evt.getArg());
-                break;
-        }
-        return down_prot.down(evt);
     }
 
     @Override
-    public Object up(Event evt) {
-        if(evt.getType() == Event.VIEW_CHANGE)
-            handleView(evt.getArg());
-        return up_prot.up(evt);
-    }
-
-    public Object up(Message msg) {
-        RaftHeader hdr=msg.getHeader(id);
-        if(hdr != null) {
-            handleMessage(msg, hdr);
-            return null;
-        }
-        return up_prot.up(msg);
-    }
-
-    public void up(MessageBatch batch) {
-        for(Iterator<Message> it=batch.iterator(); it.hasNext();) {
-            Message msg=it.next();
-            RaftHeader hdr=msg.getHeader(id);
-            if(hdr != null) {
-                it.remove();
-                handleMessage(msg, hdr);
-            }
-        }
-        if(!batch.isEmpty())
-            up_prot.up(batch);
-    }
-
-
     protected void handleView(View v) {
         Majority result=Utils.computeMajority(view, v, raft().majority(), raft.leader());
         log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, this.view, v, result);
@@ -138,189 +72,4 @@ public class ELECTION extends Protocol {
                 break;
         }
     }
-
-
-    protected void handleMessage(Message msg, RaftHeader hdr) {
-        if(hdr instanceof LeaderElected) {
-            long term=hdr.currTerm();
-            Address leader=((LeaderElected)hdr).leader();
-            stopVotingThread(); // only on the coord
-            log.trace("%s <- %s: %s", local_addr, msg.src(), hdr);
-            raft.setLeaderAndTerm(leader, term); // possibly changes the role
-            return;
-        }
-        if(hdr instanceof VoteRequest) {
-            handleVoteRequest(msg.src(), hdr.currTerm());
-            return;
-        }
-        if(hdr instanceof VoteResponse) {
-            VoteResponse rsp=(VoteResponse)hdr;
-            log.trace("%s <- %s: %s", local_addr, msg.src(), hdr);
-            handleVoteResponse(msg.src(), rsp);
-        }
-    }
-
-    /**
-     * Handle a received VoteRequest sent by the coordinator; send back the last log term and index
-     * @param sender The sender of the VoteRequest
-     */
-    protected void handleVoteRequest(Address sender, long new_term) {
-        if(log.isTraceEnabled())
-            log.trace("%s <- %s: VoteRequest(term=%d)", local_addr, sender, new_term);
-
-        int result=raft.currentTerm(new_term);
-        switch(result) {
-            case -1: // new_term < current_term
-                log.trace("%s: received vote request from %s with term=%d (current_term=%d); dropping vote response",
-                         local_addr, sender, new_term, raft.currentTerm());
-                return;
-            case 1: // new_term > current_term
-                raft.votedFor(null);
-                break;
-        }
-
-        Address voted_for=raft.votedFor();
-        if(voted_for != null && !voted_for.equals(sender)) {
-            log.trace("%s: already voted (for %s) in term %d; dropping vote request from %s",
-                     local_addr, voted_for, new_term, sender);
-            return;
-        }
-        Log log_impl=raft.log();
-        if(log_impl == null)
-            return;
-        raft.votedFor(sender);
-        long my_last_index=log_impl.lastAppended();
-        LogEntry entry=log_impl.get(my_last_index);
-        long my_last_term=entry != null? entry.term : 0;
-        sendVoteResponse(sender, new_term, my_last_term, my_last_index);
-    }
-
-    protected void handleVoteResponse(Address sender, VoteResponse rsp) {
-        votes.add(sender, rsp);
-    }
-
-
-    protected void runVotingProcess() {
-        long new_term=raft.createNewTerm();
-        raft.votedFor(null);
-        votes.reset(view.getMembersRaw());
-        num_voting_rounds++;
-        long start=System.currentTimeMillis();
-        sendVoteRequest(new_term);
-
-        // wait for responses from all members or for vote_timeout ms, whichever happens first:
-        votes.waitForAllResponses(vote_timeout);
-        long time=System.currentTimeMillis()-start;
-
-        int majority=raft.majority();
-        if(votes.numberOfValidResponses() >= majority) {
-            Address leader=determineLeader();
-            log.trace("%s: collected votes from %s in %d ms (majority=%d) -> leader is %s (new_term=%d)",
-                      local_addr, votes.getValidResults(), time, majority, leader, new_term);
-            sendLeaderElectedMessage(leader, new_term); // send to all - self
-            raft.setLeaderAndTerm(leader, new_term);
-            stopVotingThread();
-        }
-        else
-            log.trace("%s: collected votes from %s in %d ms (majority=%d); starting another voting round",
-                      local_addr, votes.getValidResults(), time, majority);
-    }
-
-    protected Address determineLeader() {
-        Address leader=null;
-        Map<Address,VoteResponse> results=votes.getResults();
-        for(Address mbr: view.getMembersRaw()) {
-            VoteResponse rsp=results.get(mbr);
-            if(rsp == null)
-                continue;
-            if(leader == null)
-                leader=mbr;
-            if(isHigher(rsp.last_log_term, rsp.last_log_index))
-                leader=mbr;
-        }
-        return leader;
-    }
-
-    protected Long highestTerm() {
-        Optional<Long> highest_term=votes.getResults().values().stream().filter(Objects::nonNull)
-          .map(RaftHeader::currTerm).max(Long::compare);
-        return highest_term.orElse(0L);
-    }
-
-
-    /** Returns true if last_term greater than my own term, false if smaller. If they're equal, returns true if
-     *  last_index is > my own last index, false otherwise
-     */
-    protected boolean isHigher(long last_term, long last_index) {
-        long my_last_index=raft.log().lastAppended();
-        LogEntry entry=raft.log().get(my_last_index);
-        long my_last_term=entry != null? entry.term : 0;
-        if(last_term > my_last_term)
-            return true;
-        if(last_term < my_last_term)
-            return false;
-        return last_index > my_last_index;
-    }
-
-    protected void sendVoteResponse(long term) {
-        long last_log_index=raft.log().lastAppended();
-        LogEntry entry=raft.log().get(last_log_index);
-        long last_log_term=entry != null? entry.term() : 0;
-        VoteResponse rsp=new VoteResponse(term, last_log_term, last_log_index);
-        log.trace("%s -> all (-self): %s", local_addr, rsp);
-        Message vote_req=new EmptyMessage(null).putHeader(id, rsp).setFlag(OOB);
-        down_prot.down(vote_req);
-    }
-
-    protected void sendVoteRequest(long new_term) {
-        VoteRequest req=new VoteRequest(new_term);
-        log.trace("%s -> all: %s", local_addr, req);
-        Message vote_req=new EmptyMessage(null).putHeader(id, req).setFlag(OOB);
-        down_prot.down(vote_req);
-    }
-
-    protected void sendVoteResponse(Address dest, long term, long last_log_term, long last_log_index) {
-        VoteResponse rsp=new VoteResponse(term, last_log_term, last_log_index);
-        Message vote_rsp=new EmptyMessage(dest).putHeader(id, rsp).setFlag(OOB);
-        down_prot.down(vote_rsp);
-    }
-
-    // sent reliably, so if a newly joined member drops it, it will get retransmitted
-    protected void sendLeaderElectedMessage(Address leader, long term) {
-        RaftHeader hdr=new LeaderElected(leader).currTerm(term);
-        Message msg=new EmptyMessage(null).putHeader(id, hdr).setFlag(DONT_LOOPBACK);
-        log.trace("%s -> all (-self): %s", local_addr, hdr);
-        down_prot.down(msg);
-    }
-
-    public synchronized ELECTION startVotingThread() {
-        if(!isVotingThreadRunning())
-            voting_thread.start();
-        return this;
-    }
-
-    public synchronized ELECTION stopVotingThread() {
-        if(isVotingThreadRunning()) {
-            log.debug("%s: stopping the voting thread", local_addr);
-            voting_thread.stop();
-            votes.reset();
-        }
-        return this;
-    }
-
-    protected <T extends Protocol> T findProtocol(Class<T> clazz) {
-        for(Protocol p=up_prot; p != null; p=p.getUpProtocol()) {
-            if(clazz.isAssignableFrom(p.getClass()))
-                return (T)p;
-        }
-        throw new IllegalStateException(clazz.getSimpleName() + " not found above " + this.getClass().getSimpleName());
-    }
-
-
-    protected static long computeElectionTimeout(long min, long max) {
-        long diff=max - min;
-        return (int)((Math.random() * 100000) % diff) + min;
-    }
-
-
 }

--- a/src/org/jgroups/protocols/raft/ELECTION2.java
+++ b/src/org/jgroups/protocols/raft/ELECTION2.java
@@ -1,0 +1,309 @@
+package org.jgroups.protocols.raft;
+
+import org.jgroups.Address;
+import org.jgroups.EmptyMessage;
+import org.jgroups.Message;
+import org.jgroups.View;
+import org.jgroups.annotations.MBean;
+import org.jgroups.annotations.ManagedAttribute;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.protocols.raft.election.BaseElection;
+import org.jgroups.protocols.raft.election.PreVoteRequest;
+import org.jgroups.protocols.raft.election.PreVoteResponse;
+import org.jgroups.raft.util.Utils;
+import org.jgroups.raft.util.Utils.Majority;
+import org.jgroups.util.ResponseCollector;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.jgroups.Message.Flag.OOB;
+
+/**
+ * A leader election protocol.
+ * <p>
+ * This implementation extends {@link ELECTION} with a pre-vote mechanism. The pre-vote always runs before starting the
+ * voting thread to define the leader. The pre-vote increases the delay in electing the leader but, in turn, covers more
+ * edge cases. As a rule of thumb, if deploying in an unstable network with frequent partitions, this protocol should
+ * give a more stable mechanism, avoid leader disruptions, and avoid possible liveness issues. Otherwise,
+ * {@link ELECTION} is the default choice.
+ *
+ * <p><h3>Pre-Voting phase:</h3>
+ *
+ * This extension includes the pre-voting mechanism proposed in Ongaro's dissertation (§9.6). In the current
+ * implementation, a pre-voting phase starts in case the current node is the new view coordinator and:
+ *
+ * <ul>
+ *     <li>The view coordinator changes and the computed update is {@link Majority#no_change};</li>
+ *     <li>The computed view update is {@link Majority#reached} or {@link Majority#leader_lost}</li>
+ * </ul>
+ *
+ * The process which executes the pre-voting mechanism sends a {@link PreVoteRequest} to all processes in the view. The
+ * recipients reply with a {@link PreVoteResponse} identifying the node they see as leader. Once the initiator receives
+ * the reply from all nodes in the view, it can start the voting process, resuming the work the same as {@link ELECTION}.
+ *
+ * @since 1.0.12
+ * @see ELECTION
+ * @see <a href="https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf">Ongaro's dissertation</a>
+ * @see <a href="https://github.com/belaban/jgroups-raft/issues/211">Issue #221</a>
+ * @author José Bolina
+ */
+@MBean(description = "Performs leader election with a pre-voting phase.")
+public class ELECTION2 extends BaseElection {
+
+    protected static final short ELECTION_ID    = 524;
+
+    static {
+        ClassConfigurator.addProtocol(ELECTION_ID, ELECTION2.class);
+        ClassConfigurator.add(PRE_VOTE_REQ, PreVoteRequest.class);
+        ClassConfigurator.add(PRE_VOTE_RSP, PreVoteResponse.class);
+    }
+
+    private final PreVotingMechanism preVotingMechanism = new PreVotingMechanism();
+
+    @ManagedAttribute(description="Whether the pre-voting is running? (Coordinator only)")
+    public boolean isPreVoteThreadRunning() {
+        return preVotingMechanism.isRunning();
+    }
+
+    @Override
+    protected void handleView(View v) {
+        Majority result = Utils.computeMajority(view, v, raft().majority(), raft.leader());
+        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, this.view, v, result);
+
+        View old_view = this.view;
+        this.view = v;
+
+        List<Address> joiners = View.newMembers(old_view, v);
+        boolean has_new_members = joiners != null && !joiners.isEmpty();
+
+        switch (result) {
+            case no_change:
+                if (raft.isLeader() && has_new_members) {
+                    sendLeaderElectedMessage(raft.leader(), raft.currentTerm());
+                    break;
+                }
+                // If we have no change in terms of majority threshold. If the view coordinator changed, we need to
+                // verify if an election is necessary.
+                if (viewCoordinatorChanged(old_view, v) && isViewCoordinator() && view.size() >= raft.majority()) {
+                    preVotingMechanism.start();
+                }
+                break;
+            case reached:
+            case leader_lost:
+                if (isViewCoordinator()) {
+                    preVotingMechanism.start();
+                }
+                break;
+            case lost:
+                raft.setLeaderAndTerm(null);
+                preVotingMechanism.stop();
+                stopVotingThread();
+                break;
+        }
+    }
+
+    @Override
+    protected void handleMessage(Message msg, RaftHeader hdr) {
+        if (hdr instanceof PreVoteRequest) {
+            handlePreVoteRequest(msg, (PreVoteRequest) hdr);
+            return;
+        }
+
+        if (hdr instanceof PreVoteResponse) {
+            handlePreVoteResponse(msg, (PreVoteResponse) hdr);
+            return;
+        }
+
+        super.handleMessage(msg, hdr);
+    }
+
+    private static boolean viewCoordinatorChanged(View old_view, View curr) {
+        if (old_view == null) return true;
+        return !Objects.equals(old_view.getCoord(), curr.getCoord());
+    }
+
+    /**
+     * Handle the {@link PreVoteRequest} coming from other nodes.
+     * <p>
+     * A node sends a {@link PreVoteRequest} to verify if it can become the leader, running the pre-voting phase
+     * instead of disrupting the cluster. The node that receives this request must only reply if they would vote for
+     * the sender in an election. Although, they can reply to different pre-votes, the node is not bound during this phase.
+     * <p>
+     * This version is an altered version of the pre-voting mechanism from the dissertation (§9.6). In this version,
+     * the node replies with its current known leader address. This is because the sender is not interested in electing
+     * itself. The sender is checking if a cluster-wide election round should be started.
+     *
+     * @param message: The message received.
+     * @param hdr: The message header.
+     */
+    private void handlePreVoteRequest(Message message, PreVoteRequest hdr) {
+        sendPreVoteResponse(message.getSrc());
+    }
+
+    private void handlePreVoteResponse(Message msg, PreVoteResponse hdr) {
+        // We are not interested in the replies if the voting phase started.
+        // Or if we are not the view coordinator.
+        if (isVotingThreadRunning() || !isViewCoordinator() || !preVotingMechanism.isRunning()) return;
+
+        preVotingMechanism.includeResponse(msg.getSrc(), hdr);
+    }
+
+    private void sendPreVotingRequest() {
+        PreVoteRequest hdr = new PreVoteRequest();
+        Message msg = new EmptyMessage(null).putHeader(id, hdr).setFlag(OOB);
+        log.trace("%s -> all: %s", local_addr, hdr);
+        down_prot.down(msg);
+    }
+
+    private void sendPreVoteResponse(Address dest) {
+        PreVoteResponse hdr = new PreVoteResponse(raft.leader());
+        Message msg = new EmptyMessage(dest).putHeader(id, hdr).setFlag(OOB);
+        log.trace("%s -> %s: %s", local_addr, dest, hdr);
+        down_prot.down(msg);
+    }
+
+    private class PreVotingMechanism {
+        protected final ResponseCollector<PreVoteResponse> preVotingResponses = new ResponseCollector<>();
+
+        public boolean isRunning() {
+            return preVotingResponses.size() > 0;
+        }
+
+        public void start() {
+            int majority = raft.majority();
+            if (!isRunning() && isViewCoordinator() && !isVotingThreadRunning() && view.getMembers().size() >= majority) {
+                log.trace("%s: starting pre-voting mechanism", local_addr);
+                startPreVotingPhase();
+            }
+        }
+
+        public void stop() {
+            log.trace("%s: stopping pre-voting thread", local_addr);
+            preVotingResponses.reset();
+        }
+
+        /**
+         * Include a new response to the running pre-vote phase.
+         * <p>
+         * Once all responses are collected and there is still a majority, the responses are parsed to verify if an
+         * election phase should start.
+         *
+         * @param sender: The response sender.
+         * @param hdr: The response message.
+         */
+        public void includeResponse(Address sender, PreVoteResponse hdr) {
+            preVotingResponses.add(sender, hdr);;
+
+            int majority = raft.majority();
+            if (preVotingResponses.hasAllResponses() && preVotingResponses.numberOfValidResponses() >= majority) {
+                Map<Address, PreVoteResponse> responses = Map.copyOf(preVotingResponses.getResults());
+                stopPreVotingPhase(responses);
+                stop();
+            } else if (log.isTraceEnabled()) {
+                log.trace("%s: collected pre-vote responses %s", local_addr, preVotingResponses.getResults());
+            }
+        }
+
+        private void startPreVotingPhase() {
+            preVotingResponses.reset(view.getMembers());
+            sendPreVotingRequest();
+        }
+
+        /**
+         * Executes after collecting messages from <b>all</b> nodes in the current view.
+         * <p>
+         * This procedure parses the responses to identify whether to start the voting thread. It has the strategy of:
+         *
+         * <ul>
+         *     <li>A majority of nodes does not have a leader or see the same "outdated" leader as this node;
+         *     <li>In case a majority sees a different leader:
+         *     <ul>
+         *         <li>The supposed leader is not in the view;
+         *         <li>The supposed leader does not see itself as leader;
+         *     </ul>
+         * </ul>
+         * <p>
+         * In case none of that matches, the election algorithm is not started.
+         *
+         * @param responses The cluster {@link PreVoteResponse} responses. Must have a response from all nodes
+         *                  in {@link #view}.
+         */
+        private void stopPreVotingPhase(Map<Address, PreVoteResponse> responses) {
+            int acceptStartVoting = 0;
+            Address localLeader = raft.leader();
+
+            log.trace("%s: validating pre-vote responses from %s", local_addr, responses);
+
+            Address remoteLeader = null;
+            for (PreVoteResponse response : responses.values()) {
+                if (response == null) continue;
+
+                Address leader = response.leader();
+
+                // The remote node either does not have a leader (== null) or has the same leader as this node.
+                // If we are at this stage, means that this node suspects the leader. For example, we have merged partitions
+                // and the remote still sees the old leader, or the node receive the message before the view update event.
+                // We count that towards starting the voting thread.
+                if (leader == null || leader.equals(localLeader)) {
+                    acceptStartVoting++;
+                } else {
+                    // Is it possible that a node is so far behind came to life with a very old leader?
+                    assert remoteLeader == null || remoteLeader.equals(leader) : "Somehow the leader is different!!";
+                    remoteLeader = leader;
+                }
+            }
+
+            // We have a majority already. Most of the nodes see an outdated or does not have a leader.
+            if (acceptStartVoting >= raft.majority()) {
+                log.debug("%s: pre-voting phase finished and starting the voting phase", local_addr);
+
+                // We can already remove the outdated leader.
+                raft.setLeaderAndTerm(null);
+                startVotingThread();
+                return;
+            }
+
+            log.trace("%s: did not met majority, taking slow-path %s", local_addr, responses);
+
+            // We did not meet the majority. We need to inspect the responses more closely. In a more concrete example:
+            // Given a cluster V1 = {A, B, C, D, E} with leader A. Suffering a quorum loss with a partial connectivity,
+            // having views: A and C have V2 = {A, C} and B, D, E still have V1.
+            // Once the connectivity is restored, A and C will merge the views and have V3 = {A, B, C, D, E}. Given that
+            // node A is the coordinator and executes the pre-voting, a majority still sees A as leader. This leads to a
+            // liveness scenario where a majority still sees the old leader, but A stepped down, and a new voting
+            // phase is never started.
+            Map<Address, Integer> votes = new HashMap<>();
+            for (PreVoteResponse response : responses.values()) {
+                if (response == null || response.leader() == null) continue;
+                votes.compute(response.leader(), (k, v) -> v == null ? 1 : v + 1);
+            }
+
+            // Compute the leader the cluster still see.
+            Address leader = null;
+            for (Map.Entry<Address, Integer> entry : votes.entrySet()) {
+                if (leader == null || entry.getValue() > votes.get(leader)) {
+                    leader = entry.getKey();
+                }
+            }
+
+            assert leader != null: "Leader should not be null at this stage: " + responses;
+            PreVoteResponse response = responses.get(leader);
+
+            // If the response is null, means the old leader is not present in the current view.
+            // The other possibility was detailed above, a cluster see the leader, but the node stepped down, and
+            // it does not see itself as a leader.
+            if (response == null || !leader.equals(response.leader())) {
+                log.debug("%s: pre-voting phase finished and starting the voting phase", local_addr);
+                startVotingThread();
+                return;
+            }
+
+            // Should receive a late message from the leader?
+            log.trace("%s: not able to start voting, majority sees %s as leader", local_addr, leader);
+        }
+    }
+}

--- a/src/org/jgroups/protocols/raft/election/BaseElection.java
+++ b/src/org/jgroups/protocols/raft/election/BaseElection.java
@@ -1,0 +1,322 @@
+package org.jgroups.protocols.raft.election;
+
+import org.jgroups.Address;
+import org.jgroups.EmptyMessage;
+import org.jgroups.Event;
+import org.jgroups.Message;
+import org.jgroups.View;
+import org.jgroups.annotations.ManagedAttribute;
+import org.jgroups.annotations.ManagedOperation;
+import org.jgroups.annotations.Property;
+import org.jgroups.conf.AttributeType;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.RaftHeader;
+import org.jgroups.stack.Protocol;
+import org.jgroups.util.MessageBatch;
+import org.jgroups.util.ResponseCollector;
+import org.jgroups.util.Runner;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.jgroups.Message.Flag.OOB;
+import static org.jgroups.Message.TransientFlag.DONT_LOOPBACK;
+
+/**
+ * Abstract leader election algorithm functionalities.
+ * <p>
+ * This abstraction includes the voting mechanism and handles messages and events from the stack. All the election
+ * algorithms extend this class. For more information, see the concrete implementations.
+ *
+ * @author Bela Ban
+ * @see org.jgroups.protocols.raft.ELECTION
+ * @see org.jgroups.protocols.raft.ELECTION2
+ */
+public abstract class BaseElection extends Protocol {
+
+    protected static final short VOTE_REQ       = 3000;
+    static final short VOTE_RSP                 = 3001;
+    static final short LEADER_ELECTED           = 3005;
+    protected static final short PRE_VOTE_REQ   = 3006;
+    protected static final short PRE_VOTE_RSP   = 3007;
+
+    static {
+        ClassConfigurator.add(VOTE_REQ,       VoteRequest.class);
+        ClassConfigurator.add(VOTE_RSP,       VoteResponse.class);
+        ClassConfigurator.add(LEADER_ELECTED, LeaderElected.class);
+    }
+
+    protected RAFT raft;
+
+    protected final Runner voting_thread=new Runner("voting-thread", this::runVotingProcess, null);
+    protected final ResponseCollector<VoteResponse> votes=new ResponseCollector<>();
+
+    protected volatile View view;
+
+    public long                            voteTimeout() {return vote_timeout;}
+    public RAFT                            raft()        {return raft;}
+    public BaseElection                    raft(RAFT r)  {raft=r; return this;}
+    public ResponseCollector<VoteResponse> getVotes()    {return votes;} // use for testing only!
+
+    @Property(description="Max time (ms) to wait for vote responses",type= AttributeType.TIME)
+    protected long               vote_timeout=600;
+
+    @ManagedAttribute(description="Number of voting rounds initiated by the coordinator")
+    protected int                num_voting_rounds;
+
+    @ManagedAttribute(description="Is the voting thread (only on the coordinator) running?")
+    public boolean isVotingThreadRunning() {return voting_thread.isRunning();}
+
+    @ManagedOperation(description="Trigger the voting process (only on the coordinator)")
+    public boolean runVotingThread() {
+        if(isViewCoordinator()) {
+            startVotingThread();
+            return isVotingThreadRunning();
+        }
+        return false;
+    }
+
+    protected abstract void handleView(View v);
+
+    public void resetStats() {
+        super.resetStats();
+        num_voting_rounds=0;
+    }
+
+    public void init() throws Exception {
+        super.init();
+        raft=findProtocol(RAFT.class);
+    }
+
+    public void stop() {
+        stopVotingThread();
+        raft.setLeaderAndTerm(null);
+    }
+
+    public Object down(Event evt) {
+        switch(evt.getType()) {
+            case Event.DISCONNECT:
+                raft.setLeaderAndTerm(null);
+                break;
+            case Event.VIEW_CHANGE:
+                handleView(evt.getArg());
+                break;
+        }
+        return down_prot.down(evt);
+    }
+
+    @Override
+    public Object up(Event evt) {
+        if(evt.getType() == Event.VIEW_CHANGE)
+            handleView(evt.getArg());
+        return up_prot.up(evt);
+    }
+
+    @Override
+    public Object up(Message msg) {
+        RaftHeader hdr=msg.getHeader(id);
+        if(hdr != null) {
+            handleMessage(msg, hdr);
+            return null;
+        }
+        return up_prot.up(msg);
+    }
+
+    @Override
+    public void up(MessageBatch batch) {
+        for(Iterator<Message> it = batch.iterator(); it.hasNext();) {
+            Message msg=it.next();
+            RaftHeader hdr=msg.getHeader(id);
+            if(hdr != null) {
+                it.remove();
+                handleMessage(msg, hdr);
+            }
+        }
+        if(!batch.isEmpty())
+            up_prot.up(batch);
+    }
+
+    protected void handleMessage(Message msg, RaftHeader hdr) {
+        if (hdr instanceof LeaderElected) {
+            handleLeaderElected(msg, (LeaderElected) hdr);
+            return;
+        }
+
+        if (hdr instanceof VoteRequest) {
+            handleVoteRequest(msg, (VoteRequest) hdr);
+            return;
+        }
+
+        if (hdr instanceof VoteResponse) {
+            handleVoteResponse(msg, (VoteResponse) hdr);
+        }
+    }
+
+    protected boolean isViewCoordinator() {
+        return Objects.equals(this.view.getCoord(), local_addr);
+    }
+
+    private void handleLeaderElected(Message msg, LeaderElected hdr) {
+        long term=hdr.currTerm();
+        Address leader=hdr.leader();
+        stopVotingThread(); // only on the coord
+        log.trace("%s <- %s: %s", local_addr, msg.src(), hdr);
+        raft.setLeaderAndTerm(leader, term); // possibly changes the role
+    }
+
+    /**
+     * Handle a received VoteRequest sent by the coordinator; send back the last log term and index. Restricts execution
+     * to a single process per term. Do not reply the request if voted for another process in the same term.
+     *
+     * @param msg: The received message.
+     * @param hdr: The received header.
+     */
+    private void handleVoteRequest(Message msg, VoteRequest hdr) {
+        Address sender = msg.src();
+        long new_term = hdr.currTerm();
+        if(log.isTraceEnabled())
+            log.trace("%s <- %s: VoteRequest(term=%d)", local_addr, sender, new_term);
+
+        int result=raft.currentTerm(new_term);
+        switch(result) {
+            case -1: // new_term < current_term
+                log.trace("%s: received vote request from %s with term=%d (current_term=%d); dropping vote response",
+                        local_addr, sender, new_term, raft.currentTerm());
+                return;
+            case 1: // new_term > current_term
+                raft.votedFor(null);
+                break;
+        }
+
+        Address voted_for=raft.votedFor();
+        if(voted_for != null && !voted_for.equals(sender)) {
+            log.trace("%s: already voted (for %s) in term %d; dropping vote request from %s",
+                    local_addr, voted_for, new_term, sender);
+            return;
+        }
+        Log log_impl=raft.log();
+        if(log_impl == null)
+            return;
+        raft.votedFor(sender);
+        long my_last_index=log_impl.lastAppended();
+        LogEntry entry=log_impl.get(my_last_index);
+        long my_last_term=entry != null? entry.term() : 0;
+        sendVoteResponse(sender, new_term, my_last_term, my_last_index);
+    }
+
+    private void handleVoteResponse(Message msg, VoteResponse hdr) {
+        votes.add(msg.src(), hdr);
+    }
+
+    protected Address determineLeader() {
+        Address leader=null;
+        Map<Address,VoteResponse> results=votes.getResults();
+        for(Address mbr: view.getMembersRaw()) {
+            VoteResponse rsp=results.get(mbr);
+            if(rsp == null)
+                continue;
+            if(leader == null)
+                leader=mbr;
+            if(isHigher(rsp.last_log_term, rsp.last_log_index))
+                leader=mbr;
+        }
+        return leader;
+    }
+
+    /**
+     * Returns true if last_term greater than my own term, false if smaller. If they're equal, returns true if
+     * last_index is > my own last index, false otherwise
+     */
+    protected boolean isHigher(long last_term, long last_index) {
+        long my_last_index=raft.log().lastAppended();
+        LogEntry entry=raft.log().get(my_last_index);
+        long my_last_term=entry != null? entry.term() : 0;
+        if(last_term > my_last_term)
+            return true;
+        if(last_term < my_last_term)
+            return false;
+        return last_index > my_last_index;
+    }
+
+    /**
+     * The mechanism for deciding a new leader.
+     * <p>
+     * Increases its term and queries all participants about their term and log index information. The thread blocks
+     * (with a timeout) wait for responses. If the majority replies, the process with the highest term and index is elected.
+     * <p>
+     * The process keeps running until a leader is elected.
+     */
+    protected void runVotingProcess() {
+        long new_term=raft.createNewTerm();
+        raft.votedFor(null);
+        votes.reset(view.getMembersRaw());
+        num_voting_rounds++;
+        long start=System.currentTimeMillis();
+        sendVoteRequest(new_term);
+
+        // wait for responses from all members or for vote_timeout ms, whichever happens first:
+        votes.waitForAllResponses(vote_timeout);
+        long time=System.currentTimeMillis()-start;
+
+        int majority=raft.majority();
+        if(votes.numberOfValidResponses() >= majority) {
+            Address leader=determineLeader();
+            log.trace("%s: collected votes from %s in %d ms (majority=%d) -> leader is %s (new_term=%d)",
+                    local_addr, votes.getValidResults(), time, majority, leader, new_term);
+            sendLeaderElectedMessage(leader, new_term); // send to all - self
+            raft.setLeaderAndTerm(leader, new_term);
+            stopVotingThread();
+        }
+        else
+            log.trace("%s: collected votes from %s in %d ms (majority=%d); starting another voting round",
+                    local_addr, votes.getValidResults(), time, majority);
+    }
+
+    public synchronized BaseElection startVotingThread() {
+        if(!isVotingThreadRunning())
+            voting_thread.start();
+        return this;
+    }
+
+    protected void sendVoteRequest(long new_term) {
+        VoteRequest req=new VoteRequest(new_term);
+        log.trace("%s -> all: %s", local_addr, req);
+        Message vote_req=new EmptyMessage(null).putHeader(id, req).setFlag(OOB);
+        down_prot.down(vote_req);
+    }
+
+    // sent reliably, so if a newly joined member drops it, it will get retransmitted
+    protected void sendLeaderElectedMessage(Address leader, long term) {
+        RaftHeader hdr=new LeaderElected(leader).currTerm(term);
+        Message msg=new EmptyMessage(null).putHeader(id, hdr).setFlag(DONT_LOOPBACK);
+        log.trace("%s -> all (-self): %s", local_addr, hdr);
+        down_prot.down(msg);
+    }
+
+    protected void sendVoteResponse(Address dest, long term, long last_log_term, long last_log_index) {
+        VoteResponse rsp=new VoteResponse(term, last_log_term, last_log_index);
+        Message vote_rsp=new EmptyMessage(dest).putHeader(id, rsp).setFlag(OOB);
+        down_prot.down(vote_rsp);
+    }
+
+    public synchronized BaseElection stopVotingThread() {
+        if(isVotingThreadRunning()) {
+            log.debug("%s: stopping the voting thread", local_addr);
+            voting_thread.stop();
+            votes.reset();
+        }
+        return this;
+    }
+
+    protected <T extends Protocol> T findProtocol(Class<T> clazz) {
+        for(Protocol p=up_prot; p != null; p=p.getUpProtocol()) {
+            if(clazz.isAssignableFrom(p.getClass()))
+                return (T)p;
+        }
+        throw new IllegalStateException(clazz.getSimpleName() + " not found above " + this.getClass().getSimpleName());
+    }
+}

--- a/src/org/jgroups/protocols/raft/election/LeaderElected.java
+++ b/src/org/jgroups/protocols/raft/election/LeaderElected.java
@@ -1,13 +1,16 @@
-package org.jgroups.protocols.raft;
+package org.jgroups.protocols.raft.election;
 
 import org.jgroups.Address;
 import org.jgroups.Header;
+import org.jgroups.protocols.raft.RaftHeader;
 import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.function.Supplier;
+
+import static org.jgroups.protocols.raft.election.BaseElection.LEADER_ELECTED;
 
 /**
  * Sent by the freshly elected leader to all members (-self)
@@ -24,7 +27,7 @@ public class LeaderElected extends RaftHeader {
 
     public Address leader()   {return leader;}
     public short getMagicId() {
-        return ELECTION.LEADER_ELECTED;
+        return LEADER_ELECTED;
     }
 
     public Supplier<? extends Header> create() {

--- a/src/org/jgroups/protocols/raft/election/PreVoteRequest.java
+++ b/src/org/jgroups/protocols/raft/election/PreVoteRequest.java
@@ -1,0 +1,33 @@
+package org.jgroups.protocols.raft.election;
+
+import org.jgroups.Header;
+import org.jgroups.protocols.raft.ELECTION2;
+import org.jgroups.protocols.raft.RaftHeader;
+
+import java.util.function.Supplier;
+
+/**
+ * Utilized during the pre-voting phase to ask nodes information about their leader.
+ *
+ * @author José Bolina
+ * @since 1.0.12
+ */
+public class PreVoteRequest extends RaftHeader {
+
+    public PreVoteRequest() { }
+
+    @Override
+    public short getMagicId() {
+        return ELECTION2.PRE_VOTE_REQ;
+    }
+
+    @Override
+    public Supplier<? extends Header> create() {
+        return PreVoteRequest::new;
+    }
+
+    @Override
+    public String toString() {
+        return "PreVote: " + super.toString();
+    }
+}

--- a/src/org/jgroups/protocols/raft/election/PreVoteResponse.java
+++ b/src/org/jgroups/protocols/raft/election/PreVoteResponse.java
@@ -1,0 +1,65 @@
+package org.jgroups.protocols.raft.election;
+
+import org.jgroups.Address;
+import org.jgroups.Header;
+import org.jgroups.protocols.raft.ELECTION2;
+import org.jgroups.protocols.raft.RaftHeader;
+import org.jgroups.util.Util;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Utilized during the pre-voting phase to return information about the current seen leader.
+ *
+ * @author José Bolina
+ * @since 1.0.12
+ */
+public class PreVoteResponse extends RaftHeader {
+
+    protected Address leader;
+
+    public PreVoteResponse() {}
+
+    public PreVoteResponse(Address leader) {
+        this.leader = leader;
+    }
+
+    public Address leader() {
+        return leader;
+    }
+
+    @Override
+    public void readFrom(DataInput in) throws IOException, ClassNotFoundException {
+        super.readFrom(in);
+        leader = Util.readAddress(in);
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+        super.writeTo(out);
+        Util.writeAddress(leader, out);
+    }
+
+    @Override
+    public int serializedSize() {
+        return super.serializedSize() + Util.size(leader);
+    }
+
+    @Override
+    public short getMagicId() {
+        return ELECTION2.PRE_VOTE_RSP;
+    }
+
+    @Override
+    public Supplier<? extends Header> create() {
+        return PreVoteResponse::new;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ": leader=" + leader;
+    }
+}

--- a/src/org/jgroups/protocols/raft/election/VoteRequest.java
+++ b/src/org/jgroups/protocols/raft/election/VoteRequest.java
@@ -1,8 +1,11 @@
-package org.jgroups.protocols.raft;
+package org.jgroups.protocols.raft.election;
 
 import org.jgroups.Header;
+import org.jgroups.protocols.raft.RaftHeader;
 
 import java.util.function.Supplier;
+
+import static org.jgroups.protocols.raft.election.BaseElection.VOTE_REQ;
 
 /**
  * @author Bela Ban
@@ -16,7 +19,7 @@ public class VoteRequest extends RaftHeader {
     }
 
     public short getMagicId() {
-        return ELECTION.VOTE_REQ;
+        return VOTE_REQ;
     }
 
     public Supplier<? extends Header> create() {

--- a/src/org/jgroups/protocols/raft/election/VoteResponse.java
+++ b/src/org/jgroups/protocols/raft/election/VoteResponse.java
@@ -1,12 +1,15 @@
-package org.jgroups.protocols.raft;
+package org.jgroups.protocols.raft.election;
 
 import org.jgroups.Header;
+import org.jgroups.protocols.raft.RaftHeader;
 import org.jgroups.util.Bits;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.function.Supplier;
+
+import static org.jgroups.protocols.raft.election.BaseElection.VOTE_RSP;
 
 /**
  * @author Bela Ban
@@ -24,7 +27,7 @@ public class VoteResponse extends RaftHeader {
     }
 
     public short getMagicId() {
-        return ELECTION.VOTE_RSP;
+        return VOTE_RSP;
     }
 
     public Supplier<? extends Header> create() {

--- a/src/org/jgroups/raft/testfwk/MockRaftCluster.java
+++ b/src/org/jgroups/raft/testfwk/MockRaftCluster.java
@@ -1,0 +1,37 @@
+package org.jgroups.raft.testfwk;
+
+import org.jgroups.Message;
+import org.jgroups.View;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public abstract class MockRaftCluster {
+
+    protected final Executor thread_pool=createThreadPool(1000);
+    protected boolean        async;
+
+    public abstract void handleView(View view);
+
+    public abstract void send(Message msg);
+
+    @SuppressWarnings("unchecked")
+    protected  <T extends MockRaftCluster> T self() {
+        return (T) this;
+    }
+
+    public boolean     async()                            {return async;}
+    public <T extends MockRaftCluster> T async(boolean b) {async=b; return self();}
+
+    protected static Executor createThreadPool(long max_idle_ms) {
+        int max_cores=Runtime.getRuntime().availableProcessors();
+        return new ThreadPoolExecutor(0, max_cores, max_idle_ms, TimeUnit.MILLISECONDS,
+                new SynchronousQueue<>());
+    }
+
+    protected void deliverAsync(RaftNode node, Message msg) {
+        thread_pool.execute(() -> node.up(msg));
+    }
+}

--- a/src/org/jgroups/raft/testfwk/PartitionedRaftCluster.java
+++ b/src/org/jgroups/raft/testfwk/PartitionedRaftCluster.java
@@ -1,0 +1,69 @@
+package org.jgroups.raft.testfwk;
+
+import org.jgroups.Address;
+import org.jgroups.Message;
+import org.jgroups.View;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manipulate the cluster during tests.
+ * <p>
+ * This class offers the possibility of creating partitions in the cluster. The partitions are created by view updates.
+ *
+ * @since 1.0.12
+ * @author José Bolina
+ */
+public class PartitionedRaftCluster extends MockRaftCluster {
+    protected final Map<Address, List<Address>> partitions = new ConcurrentHashMap<>();
+    protected final Map<Address, RaftNode> nodes = new ConcurrentHashMap<>();
+
+    public PartitionedRaftCluster clear() {nodes.clear(); return this;}
+
+    public PartitionedRaftCluster add(Address addr, RaftNode node) {
+        nodes.put(addr, node);
+        return this;
+    }
+
+    @Override
+    public void handleView(View view) {
+        List<Address> members = view.getMembers();
+        for (Address member : members) {
+            partitions.put(member, members);
+        }
+
+        for (Address member : members) {
+            RaftNode node = nodes.get(member);
+            node.handleView(view);
+        }
+    }
+
+    @Override
+    public void send(Message msg) {
+        Address dest=msg.dest(), src=msg.src();
+        if(dest != null) {
+            List<Address> connected = partitions.get(src);
+            if (connected.contains(dest)) {
+                RaftNode node = nodes.get(dest);
+                send(node, msg);
+            }
+        } else {
+            for (Address a : partitions.get(src)) {
+                RaftNode node = nodes.get(a);
+                send(node, msg);
+            }
+
+            if (!msg.isFlagSet(Message.TransientFlag.DONT_LOOPBACK)) {
+                RaftNode node = nodes.get(src);
+                send(node, msg);
+            }
+        }
+    }
+
+    private void send(RaftNode node, Message msg) {
+        if (async) deliverAsync(node, msg);
+        else node.up(msg);
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/PartialConnectivityTest.java
+++ b/tests/junit-functional/org/jgroups/tests/PartialConnectivityTest.java
@@ -1,0 +1,159 @@
+package org.jgroups.tests;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.ELECTION;
+import org.jgroups.protocols.raft.ELECTION2;
+import org.jgroups.protocols.raft.InMemoryLog;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.election.BaseElection;
+import org.jgroups.raft.testfwk.PartitionedRaftCluster;
+import org.jgroups.raft.testfwk.RaftNode;
+import org.jgroups.raft.util.Utils;
+import org.jgroups.stack.Protocol;
+import org.jgroups.util.ExtendedUUID;
+import org.jgroups.util.Util;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Test(groups= Global.FUNCTIONAL, singleThreaded=true)
+public class PartialConnectivityTest {
+
+    private static final String CLUSTER = PartialConnectivityTest.class.getSimpleName();
+    protected final PartitionedRaftCluster cluster = new PartitionedRaftCluster();
+    protected final List<String> members= Arrays.asList("A", "B", "C", "D", "E");
+    protected RaftNode[] nodes;
+    protected RaftNode a, b, c, d, e;
+    protected RAFT[] rafts;
+    protected Class<? extends BaseElection> electionClass;
+
+    public PartialConnectivityTest() { }
+
+    public PartialConnectivityTest(Class<? extends BaseElection> electionClass) {
+        this.electionClass = electionClass;
+    }
+
+    @BeforeMethod
+    protected void init() throws Exception {
+        nodes = new RaftNode[5];
+        rafts = new RAFT[5];
+
+        int i=0;
+        a = createNode("A", i++);
+        b = createNode("B", i++);
+        c = createNode("C", i++);
+        d = createNode("D", i++);
+        e = createNode("E", i);
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        for (int i=nodes.length - 1; i >= 0; i--) {
+            nodes[i].stop();
+            nodes[i].destroy();
+            Utils.deleteLog(rafts[i]);
+        }
+        Util.close(a,b,c,d,e);
+        cluster.clear();
+    }
+
+    @Factory
+    protected static Object[] electionClass() {
+        return new Object[] {
+                new PartialConnectivityTest(ELECTION.class),
+                new PartialConnectivityTest(ELECTION2.class),
+        };
+    }
+
+    public void testQuorumLossAndRecovery() {
+        long id=1;
+
+        View initial=createView(id++, a,b,c,d,e);
+        cluster.handleView(initial);
+
+        assert Util.waitUntilTrue(5000, 200, () -> Stream.of(nodes).allMatch(n -> n.raft().leader() != null));
+        List<Address> leaders = leaders(nodes);
+        assert leaders.size() == 1 : "there should be only one leader, but found " + leaders;
+        Address leader = leaders.get(0);
+
+        System.out.println("leader is " + leader);
+
+        // Nodes D and E do not update their view.
+        cluster.handleView(createView(id++, a, c));
+        cluster.handleView(createView(id++, b, c));
+
+        assert Util.waitUntilTrue(3000, 200, () -> Stream.of(a, b, c).allMatch(n -> n.raft().leader() == null));
+
+        assert leader.equals(d.raft().leader()) : "leader should be " + leader + ", but found " + d.raft().leader();
+        assert leader.equals(e.raft().leader()) : "leader should be " + leader + ", but found " + e.raft().leader();
+
+        for (RaftNode n : nodes) {
+            assert !n.election().isVotingThreadRunning() : "election thread should not be running in " + n;
+        }
+
+        View after = createView(id++, e, d, a, b, c);
+        System.out.println("after restored network: " + after);
+        cluster.handleView(after);
+
+        boolean elected = Util.waitUntilTrue(3000, 200, () -> Stream.of(nodes).allMatch(n -> n.raft().leader() != null));
+        if (electionClass.equals(ELECTION2.class)) {
+            assert elected : "leader was never elected again";
+            leaders = leaders(nodes);
+            assert leaders.size() == 1 : "there should be only one leader, but found " + leaders;
+            System.out.println("Leader after restored network: " + leaders.get(0));
+        } else {
+            assert !elected : "leader was elected again";
+            assert electionClass.equals(ELECTION.class);
+        }
+    }
+
+    protected static View createView(long id, RaftNode... mbrs) {
+        List<Address> l=Stream.of(mbrs).filter(Objects::nonNull).map(RaftNode::getAddress).collect(Collectors.toList());
+        return View.create(l.get(0), id, l);
+    }
+
+    protected static Address createAddress(String name) {
+        ExtendedUUID.setPrintFunction(RAFT.print_function);
+        return ExtendedUUID.randomUUID(name).put(RAFT.raft_id_key, Util.stringToBytes(name));
+    }
+
+    protected RaftNode createNode(String name, int i) throws Exception {
+        Address a=createAddress(name);
+        RAFT r=rafts[i]=new RAFT().members(members).raftId(name)
+                .logClass(InMemoryLog.class.getCanonicalName())
+                .logPrefix(name + "-" + CLUSTER)
+                .stateMachine(new DummyStateMachine())
+                .synchronous(true)
+                .setAddress(a);
+        BaseElection e=election(r, a);
+        RaftNode node=nodes[i]=new RaftNode(cluster, new Protocol[]{e, r});
+        node.init();
+        node.start();
+        cluster.add(a, node);
+        return node;
+    }
+
+    private BaseElection election(RAFT r, Address a) throws Exception {
+        return electionClass.getConstructor().newInstance().raft(r).setAddress(a);
+    }
+
+    public static List<Address> leaders(RaftNode... nodes) {
+        List<Address> leaders = new ArrayList<>();
+        for (RaftNode node : nodes) {
+            if (node.raft().isLeader()) {
+                leaders.add(node.getAddress());
+            }
+        }
+        return leaders;
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/RaftHeaderTest.java
+++ b/tests/junit-functional/org/jgroups/tests/RaftHeaderTest.java
@@ -2,6 +2,8 @@ package org.jgroups.tests;
 
 import org.jgroups.Global;
 import org.jgroups.protocols.raft.*;
+import org.jgroups.protocols.raft.election.VoteRequest;
+import org.jgroups.protocols.raft.election.VoteResponse;
 import org.jgroups.raft.Options;
 import org.jgroups.util.ByteArrayDataOutputStream;
 import org.jgroups.util.Util;

--- a/tests/junit-functional/org/jgroups/tests/election/BaseElectionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/BaseElectionTest.java
@@ -1,0 +1,33 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.protocols.raft.ELECTION;
+import org.jgroups.protocols.raft.ELECTION2;
+import org.jgroups.protocols.raft.election.BaseElection;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+
+public class BaseElectionTest {
+    public static final String ALL_ELECTION_CLASSES_PROVIDER = "all-election-classes";
+
+    protected Class<? extends BaseElection> electionClass;
+
+    public BaseElection instantiate() throws Exception {
+        assert electionClass != null : "Election class not set";
+        // The default constructor is always available.
+        return electionClass.getDeclaredConstructor().newInstance();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @SuppressWarnings("unchecked")
+    protected void setElectionClass(Object[] args) {
+        electionClass = (Class<? extends BaseElection>) args[0];
+    }
+
+    @DataProvider(name = ALL_ELECTION_CLASSES_PROVIDER)
+    protected static Object[][] electionClasses() {
+        return new Object[][] {
+                {ELECTION.class},
+                {ELECTION2.class},
+        };
+    }
+}


### PR DESCRIPTION
Closes #211. I followed the suggestion and created a `BaseElection` class to abstract the voting functionality. This includes:

* Move part of the `ELECTION` logic to `BaseElection`;
* The pre-voting mechanism is available on `ELECTION2`;
* I added an operation to trigger the leader election manually;

On the testing side:

* The election-related tests run with both `ELECTION` and `ELECTION2` protocols.

Let me know what you think.