### PR TITLE
Fix: isLeader() returns true, even if leader is null

### DIFF
--- a/src/org/jgroups/protocols/raft/RAFT.java
+++ b/src/org/jgroups/protocols/raft/RAFT.java
@@ -261,7 +261,7 @@ public class RAFT extends Protocol implements Settable, DynamicMembership {
     @ManagedAttribute(description="The current leader (can be null if there is currently no leader) ")
     public Address      leader()                      {return raft_state.leader();}
     public RAFT         leader(Address new_leader)    {this.raft_state.setLeader(new_leader); return this;}
-    public boolean      isLeader()                    {return Objects.equals(leader(), local_addr);}
+    public boolean      isLeader()                    {return leader() != null && Objects.equals(leader(), local_addr);}
 
     public RAFT         stateMachine(StateMachine sm) {
         boolean load = state_machine == null && !state_machine_loaded;


### PR DESCRIPTION
Hi,

**Fix `isLeader()` to return `false` when `leader()` is `null`**

### Problem
The `isLeader()` method in `RAFT.java` returns `true` when both `leader()` and `local_addr` are `null`, due to `Object.equals(null, null)` evaluating to `true`. This is incorrect because a node with no defined leader should not be considered a leader. The issue arises in uninitialized states, such as before a `RaftHandle` connects to a cluster.

### Impact
In dynamic Raft clusters, nodes may check `isLeader()` before performing leader-only actions. If `isLeader()` incorrectly returns `true`, it can lead to errors like:

```java
RaftHandle raftHandle = new RaftHandle(ch, sm);
// Not yet connected to cluster
if (raftHandle.isLeader()) { // Returns true (incorrectly)
    raftHandle.addServer(); // Throws IllegalStateException: I'm not the leader (local_addr=null, leader=null)
}
```

### Solution

This PR modifies isLeader() to return true only if leader() is non-null and equals local_addr:

```java
boolean isLeader() {
    return leader() != null && Object.equals(leader(), local_addr);
}
```

### Notes:

- I haven’t added tests yet but can do so if needed. The change is small and focused, but I’d appreciate feedback on edge cases I might have missed.
- Let me know if there’s a reason the original behavior was intentional or if further adjustments are required!

Thanks for reviewing!